### PR TITLE
change link for user-requests #64

### DIFF
--- a/index.html
+++ b/index.html
@@ -103,7 +103,7 @@
       </p>
       <ul>
         <li>
-          <a href="https://github.com/terasolunaorg/guideline/issues">開発ガイドライン</a>
+          <a href="https://github.com/terasolunaorg/terasolunaorg.github.com/issues">開発ガイドライン</a>
         </li>
         <li>
           <a href="https://github.com/terasolunaorg/terasoluna-gfw/issues">共通ライブラリ</a>

--- a/index_en.html
+++ b/index_en.html
@@ -102,7 +102,7 @@
       </p>
       <ul>
         <li>
-          <a href="https://github.com/terasolunaorg/guideline/issues">Development Guideline</a>
+          <a href="https://github.com/terasolunaorg/terasolunaorg.github.com/issues">Development Guideline</a>
         </li>
         <li>
           <a href="https://github.com/terasolunaorg/terasoluna-gfw/issues">Common Library</a>


### PR DESCRIPTION
Please review #64.

I changed the link for issue page of Development Guideline in [TERASOLUNA top page](http://terasolunaorg.github.io/) as below.

Before `https://github.com/terasolunaorg/guideline/issues`
After `https://github.com/terasolunaorg/terasolunaorg.github.com/issues`

This pull request includes the changes for Japanese and English pages.