### PR TITLE
set GA4 to 5.6.0.SP1.RELEASE

### DIFF
--- a/guideline/5.6.0.SP1.RELEASE/ja/Appendix/Java11Changes.html
+++ b/guideline/5.6.0.SP1.RELEASE/ja/Appendix/Java11Changes.html
@@ -22,7 +22,13 @@
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />
     <link rel="next" title="12.4. 参考書籍" href="ReferenceBooks.html" />
-    <link rel="prev" title="12.2. ボイラープレートコードの排除(Lombok)" href="Lombok.html" /><script src="../_static/jquery.treeview.js" type="text/javascript"></script>
+    <link rel="prev" title="12.2. ボイラープレートコードの排除(Lombok)" href="Lombok.html" /><script async src="https://www.googletagmanager.com/gtag/js?id=G-847V2Q99G8"></script>
+<script>
+window.dataLayer = window.dataLayer || [];
+function gtag(){dataLayer.push(arguments);}
+gtag('js', new Date()); gtag('config', 'G-847V2Q99G8');
+</script>
+<script src="../_static/jquery.treeview.js" type="text/javascript"></script>
 <!-- <link href='http://fonts.googleapis.com/css?family=Source+Code+Pro|Open+Sans:300italic,400italic,700italic,400,300,700' rel='stylesheet' type='text/css'> -->
 <link href="../_static/solarized-dark.css" rel="stylesheet">
 <link href="../_static/jquery.treeview.css" rel="stylesheet">
@@ -98,10 +104,6 @@
             
   <div class="section" id="java-se-8java-se-11">
 <h1>12.3. Java SE 8からJava SE 11までの主要な変更点<a class="headerlink" href="#java-se-8java-se-11" title="Permalink to this headline">¶</a></h1>
-<div class="admonition caution">
-  <p class="first admonition-title">Caution</p>
-  <p><strong>本バージョンの内容は既に古くなっています</strong>。最新のガイドラインは<a href="http://terasolunaorg.github.io/guideline/">こちら</a>からご参照ください。</p>
-</div>
 <div class="contents local topic" id="id1">
 <p class="topic-title">目次</p>
 <ul class="simple">

--- a/guideline/5.6.0.SP1.RELEASE/ja/Appendix/Lombok.html
+++ b/guideline/5.6.0.SP1.RELEASE/ja/Appendix/Lombok.html
@@ -22,7 +22,13 @@
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />
     <link rel="next" title="12.3. Java SE 8からJava SE 11までの主要な変更点" href="Java11Changes.html" />
-    <link rel="prev" title="12.1. NEXUSによるMavenリポジトリの管理" href="Nexus.html" /><script src="../_static/jquery.treeview.js" type="text/javascript"></script>
+    <link rel="prev" title="12.1. NEXUSによるMavenリポジトリの管理" href="Nexus.html" /><script async src="https://www.googletagmanager.com/gtag/js?id=G-847V2Q99G8"></script>
+<script>
+window.dataLayer = window.dataLayer || [];
+function gtag(){dataLayer.push(arguments);}
+gtag('js', new Date()); gtag('config', 'G-847V2Q99G8');
+</script>
+<script src="../_static/jquery.treeview.js" type="text/javascript"></script>
 <!-- <link href='http://fonts.googleapis.com/css?family=Source+Code+Pro|Open+Sans:300italic,400italic,700italic,400,300,700' rel='stylesheet' type='text/css'> -->
 <link href="../_static/solarized-dark.css" rel="stylesheet">
 <link href="../_static/jquery.treeview.css" rel="stylesheet">
@@ -110,10 +116,6 @@
             
   <div class="section" id="lombok">
 <h1>12.2. ボイラープレートコードの排除(Lombok)<a class="headerlink" href="#lombok" title="Permalink to this headline">¶</a></h1>
-<div class="admonition caution">
-  <p class="first admonition-title">Caution</p>
-  <p><strong>本バージョンの内容は既に古くなっています</strong>。最新のガイドラインは<a href="http://terasolunaorg.github.io/guideline/">こちら</a>からご参照ください。</p>
-</div>
 <div class="contents local topic" id="id1">
 <p class="topic-title">目次</p>
 <ul class="simple">

--- a/guideline/5.6.0.SP1.RELEASE/ja/Appendix/Nexus.html
+++ b/guideline/5.6.0.SP1.RELEASE/ja/Appendix/Nexus.html
@@ -22,7 +22,13 @@
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />
     <link rel="next" title="12.2. ボイラープレートコードの排除(Lombok)" href="Lombok.html" />
-    <link rel="prev" title="12. Appendix(Know How)" href="index.html" /><script src="../_static/jquery.treeview.js" type="text/javascript"></script>
+    <link rel="prev" title="12. Appendix(Know How)" href="index.html" /><script async src="https://www.googletagmanager.com/gtag/js?id=G-847V2Q99G8"></script>
+<script>
+window.dataLayer = window.dataLayer || [];
+function gtag(){dataLayer.push(arguments);}
+gtag('js', new Date()); gtag('config', 'G-847V2Q99G8');
+</script>
+<script src="../_static/jquery.treeview.js" type="text/javascript"></script>
 <!-- <link href='http://fonts.googleapis.com/css?family=Source+Code+Pro|Open+Sans:300italic,400italic,700italic,400,300,700' rel='stylesheet' type='text/css'> -->
 <link href="../_static/solarized-dark.css" rel="stylesheet">
 <link href="../_static/jquery.treeview.css" rel="stylesheet">
@@ -97,10 +103,6 @@
             
   <div class="section" id="nexusmaven">
 <h1>12.1. NEXUSによるMavenリポジトリの管理<a class="headerlink" href="#nexusmaven" title="Permalink to this headline">¶</a></h1>
-<div class="admonition caution">
-  <p class="first admonition-title">Caution</p>
-  <p><strong>本バージョンの内容は既に古くなっています</strong>。最新のガイドラインは<a href="http://terasolunaorg.github.io/guideline/">こちら</a>からご参照ください。</p>
-</div>
 <p><a class="reference external" href="http://www.sonatype.org/nexus/">Sonatype NEXUS</a> はパッケージリポジトリマネージャソフトウェアである。
 OSS版と商用版があるが、OSS版でも十分な機能がある。</p>
 <p>本章ではOSS版のNEXUSの役割と設定方法などについて解決する。</p>

--- a/guideline/5.6.0.SP1.RELEASE/ja/Appendix/ReferenceBooks.html
+++ b/guideline/5.6.0.SP1.RELEASE/ja/Appendix/ReferenceBooks.html
@@ -22,7 +22,13 @@
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />
     <link rel="next" title="12.5. Spring Framework理解度チェックテスト" href="SpringComprehensionCheck.html" />
-    <link rel="prev" title="12.3. Java SE 8からJava SE 11までの主要な変更点" href="Java11Changes.html" /><script src="../_static/jquery.treeview.js" type="text/javascript"></script>
+    <link rel="prev" title="12.3. Java SE 8からJava SE 11までの主要な変更点" href="Java11Changes.html" /><script async src="https://www.googletagmanager.com/gtag/js?id=G-847V2Q99G8"></script>
+<script>
+window.dataLayer = window.dataLayer || [];
+function gtag(){dataLayer.push(arguments);}
+gtag('js', new Date()); gtag('config', 'G-847V2Q99G8');
+</script>
+<script src="../_static/jquery.treeview.js" type="text/javascript"></script>
 <!-- <link href='http://fonts.googleapis.com/css?family=Source+Code+Pro|Open+Sans:300italic,400italic,700italic,400,300,700' rel='stylesheet' type='text/css'> -->
 <link href="../_static/solarized-dark.css" rel="stylesheet">
 <link href="../_static/jquery.treeview.css" rel="stylesheet">
@@ -81,10 +87,6 @@
             
   <div class="section" id="id1">
 <h1>12.4. 参考書籍<a class="headerlink" href="#id1" title="Permalink to this headline">¶</a></h1>
-<div class="admonition caution">
-  <p class="first admonition-title">Caution</p>
-  <p><strong>本バージョンの内容は既に古くなっています</strong>。最新のガイドラインは<a href="http://terasolunaorg.github.io/guideline/">こちら</a>からご参照ください。</p>
-</div>
 <p>本ガイドラインを執筆する上で参考にした書籍を列挙する。必要に応じて参照されたい。</p>
 <table border="1" class="colwidths-given docutils">
 <colgroup>

--- a/guideline/5.6.0.SP1.RELEASE/ja/Appendix/SpringComprehensionCheck.html
+++ b/guideline/5.6.0.SP1.RELEASE/ja/Appendix/SpringComprehensionCheck.html
@@ -21,7 +21,13 @@
     <script type="text/javascript" src="../_static/doctools.js"></script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />
-    <link rel="prev" title="12.4. 参考書籍" href="ReferenceBooks.html" /><script src="../_static/jquery.treeview.js" type="text/javascript"></script>
+    <link rel="prev" title="12.4. 参考書籍" href="ReferenceBooks.html" /><script async src="https://www.googletagmanager.com/gtag/js?id=G-847V2Q99G8"></script>
+<script>
+window.dataLayer = window.dataLayer || [];
+function gtag(){dataLayer.push(arguments);}
+gtag('js', new Date()); gtag('config', 'G-847V2Q99G8');
+</script>
+<script src="../_static/jquery.treeview.js" type="text/javascript"></script>
 <!-- <link href='http://fonts.googleapis.com/css?family=Source+Code+Pro|Open+Sans:300italic,400italic,700italic,400,300,700' rel='stylesheet' type='text/css'> -->
 <link href="../_static/solarized-dark.css" rel="stylesheet">
 <link href="../_static/jquery.treeview.css" rel="stylesheet">
@@ -74,10 +80,6 @@
             
   <div class="section" id="spring-framework">
 <h1>12.5. Spring Framework理解度チェックテスト<a class="headerlink" href="#spring-framework" title="Permalink to this headline">¶</a></h1>
-<div class="admonition caution">
-  <p class="first admonition-title">Caution</p>
-  <p><strong>本バージョンの内容は既に古くなっています</strong>。最新のガイドラインは<a href="http://terasolunaorg.github.io/guideline/">こちら</a>からご参照ください。</p>
-</div>
 <ol class="arabic">
 <li><p class="first">Beanの依存関係が以下の図のようになるように(1)～(4)を埋めてください。import文は省略してください。</p>
 <blockquote>

--- a/guideline/5.6.0.SP1.RELEASE/ja/Appendix/index.html
+++ b/guideline/5.6.0.SP1.RELEASE/ja/Appendix/index.html
@@ -22,7 +22,13 @@
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />
     <link rel="next" title="12.1. NEXUSによるMavenリポジトリの管理" href="Nexus.html" />
-    <link rel="prev" title="11.4. Spring Securityチュートリアル" href="../Tutorial/TutorialSecurity.html" /><script src="../_static/jquery.treeview.js" type="text/javascript"></script>
+    <link rel="prev" title="11.4. Spring Securityチュートリアル" href="../Tutorial/TutorialSecurity.html" /><script async src="https://www.googletagmanager.com/gtag/js?id=G-847V2Q99G8"></script>
+<script>
+window.dataLayer = window.dataLayer || [];
+function gtag(){dataLayer.push(arguments);}
+gtag('js', new Date()); gtag('config', 'G-847V2Q99G8');
+</script>
+<script src="../_static/jquery.treeview.js" type="text/javascript"></script>
 <!-- <link href='http://fonts.googleapis.com/css?family=Source+Code+Pro|Open+Sans:300italic,400italic,700italic,400,300,700' rel='stylesheet' type='text/css'> -->
 <link href="../_static/solarized-dark.css" rel="stylesheet">
 <link href="../_static/jquery.treeview.css" rel="stylesheet">
@@ -80,10 +86,6 @@
             
   <div class="section" id="appendix-know-how">
 <h1>12. Appendix(Know How)<a class="headerlink" href="#appendix-know-how" title="Permalink to this headline">¶</a></h1>
-<div class="admonition caution">
-  <p class="first admonition-title">Caution</p>
-  <p><strong>本バージョンの内容は既に古くなっています</strong>。最新のガイドラインは<a href="http://terasolunaorg.github.io/guideline/">こちら</a>からご参照ください。</p>
-</div>
 <div class="toctree-wrapper compound">
 <ul>
 <li class="toctree-l1"><a class="reference internal" href="Nexus.html">12.1. NEXUSによるMavenリポジトリの管理</a></li>

--- a/guideline/5.6.0.SP1.RELEASE/ja/ArchitectureInDetail/DataAccessDetail/DataAccessCommon.html
+++ b/guideline/5.6.0.SP1.RELEASE/ja/ArchitectureInDetail/DataAccessDetail/DataAccessCommon.html
@@ -22,7 +22,13 @@
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />
     <link rel="next" title="6.2. データベースアクセス（MyBatis3編）" href="DataAccessMyBatis3.html" />
-    <link rel="prev" title="6. データアクセス" href="index.html" /><script src="../../_static/jquery.treeview.js" type="text/javascript"></script>
+    <link rel="prev" title="6. データアクセス" href="index.html" /><script async src="https://www.googletagmanager.com/gtag/js?id=G-847V2Q99G8"></script>
+<script>
+window.dataLayer = window.dataLayer || [];
+function gtag(){dataLayer.push(arguments);}
+gtag('js', new Date()); gtag('config', 'G-847V2Q99G8');
+</script>
+<script src="../../_static/jquery.treeview.js" type="text/javascript"></script>
 <!-- <link href='http://fonts.googleapis.com/css?family=Source+Code+Pro|Open+Sans:300italic,400italic,700italic,400,300,700' rel='stylesheet' type='text/css'> -->
 <link href="../../_static/solarized-dark.css" rel="stylesheet">
 <link href="../../_static/jquery.treeview.css" rel="stylesheet">
@@ -145,10 +151,6 @@
             
   <div class="section" id="id1">
 <h1>6.1. データベースアクセス（共通編）<a class="headerlink" href="#id1" title="Permalink to this headline">¶</a></h1>
-<div class="admonition caution">
-  <p class="first admonition-title">Caution</p>
-  <p><strong>本バージョンの内容は既に古くなっています</strong>。最新のガイドラインは<a href="http://terasolunaorg.github.io/guideline/">こちら</a>からご参照ください。</p>
-</div>
 <div class="contents local topic" id="id2">
 <p class="topic-title">目次</p>
 <ul class="simple">

--- a/guideline/5.6.0.SP1.RELEASE/ja/ArchitectureInDetail/DataAccessDetail/DataAccessJpa.html
+++ b/guideline/5.6.0.SP1.RELEASE/ja/ArchitectureInDetail/DataAccessDetail/DataAccessJpa.html
@@ -22,7 +22,13 @@
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />
     <link rel="next" title="6.4. 排他制御" href="ExclusionControl.html" />
-    <link rel="prev" title="6.2. データベースアクセス（MyBatis3編）" href="DataAccessMyBatis3.html" /><script src="../../_static/jquery.treeview.js" type="text/javascript"></script>
+    <link rel="prev" title="6.2. データベースアクセス（MyBatis3編）" href="DataAccessMyBatis3.html" /><script async src="https://www.googletagmanager.com/gtag/js?id=G-847V2Q99G8"></script>
+<script>
+window.dataLayer = window.dataLayer || [];
+function gtag(){dataLayer.push(arguments);}
+gtag('js', new Date()); gtag('config', 'G-847V2Q99G8');
+</script>
+<script src="../../_static/jquery.treeview.js" type="text/javascript"></script>
 <!-- <link href='http://fonts.googleapis.com/css?family=Source+Code+Pro|Open+Sans:300italic,400italic,700italic,400,300,700' rel='stylesheet' type='text/css'> -->
 <link href="../../_static/solarized-dark.css" rel="stylesheet">
 <link href="../../_static/jquery.treeview.css" rel="stylesheet">
@@ -192,10 +198,6 @@
             
   <div class="section" id="jpa">
 <h1>6.3. データベースアクセス（JPA編）<a class="headerlink" href="#jpa" title="Permalink to this headline">¶</a></h1>
-<div class="admonition caution">
-  <p class="first admonition-title">Caution</p>
-  <p><strong>本バージョンの内容は既に古くなっています</strong>。最新のガイドラインは<a href="http://terasolunaorg.github.io/guideline/">こちら</a>からご参照ください。</p>
-</div>
 <div class="contents local topic" id="id1">
 <p class="topic-title">目次</p>
 <ul class="simple">

--- a/guideline/5.6.0.SP1.RELEASE/ja/ArchitectureInDetail/DataAccessDetail/DataAccessMyBatis3.html
+++ b/guideline/5.6.0.SP1.RELEASE/ja/ArchitectureInDetail/DataAccessDetail/DataAccessMyBatis3.html
@@ -22,7 +22,13 @@
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />
     <link rel="next" title="6.3. データベースアクセス（JPA編）" href="DataAccessJpa.html" />
-    <link rel="prev" title="6.1. データベースアクセス（共通編）" href="DataAccessCommon.html" /><script src="../../_static/jquery.treeview.js" type="text/javascript"></script>
+    <link rel="prev" title="6.1. データベースアクセス（共通編）" href="DataAccessCommon.html" /><script async src="https://www.googletagmanager.com/gtag/js?id=G-847V2Q99G8"></script>
+<script>
+window.dataLayer = window.dataLayer || [];
+function gtag(){dataLayer.push(arguments);}
+gtag('js', new Date()); gtag('config', 'G-847V2Q99G8');
+</script>
+<script src="../../_static/jquery.treeview.js" type="text/javascript"></script>
 <!-- <link href='http://fonts.googleapis.com/css?family=Source+Code+Pro|Open+Sans:300italic,400italic,700italic,400,300,700' rel='stylesheet' type='text/css'> -->
 <link href="../../_static/solarized-dark.css" rel="stylesheet">
 <link href="../../_static/jquery.treeview.css" rel="stylesheet">
@@ -233,10 +239,6 @@
             
   <div class="section" id="mybatis3">
 <h1>6.2. データベースアクセス（MyBatis3編）<a class="headerlink" href="#mybatis3" title="Permalink to this headline">¶</a></h1>
-<div class="admonition caution">
-  <p class="first admonition-title">Caution</p>
-  <p><strong>本バージョンの内容は既に古くなっています</strong>。最新のガイドラインは<a href="http://terasolunaorg.github.io/guideline/">こちら</a>からご参照ください。</p>
-</div>
 <div class="contents local topic" id="id1">
 <p class="topic-title">目次</p>
 <ul class="simple">

--- a/guideline/5.6.0.SP1.RELEASE/ja/ArchitectureInDetail/DataAccessDetail/ExclusionControl.html
+++ b/guideline/5.6.0.SP1.RELEASE/ja/ArchitectureInDetail/DataAccessDetail/ExclusionControl.html
@@ -22,7 +22,13 @@
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />
     <link rel="next" title="7. アプリケーション形態に依存しない汎用機能" href="../GeneralFuncDetail/index.html" />
-    <link rel="prev" title="6.3. データベースアクセス（JPA編）" href="DataAccessJpa.html" /><script src="../../_static/jquery.treeview.js" type="text/javascript"></script>
+    <link rel="prev" title="6.3. データベースアクセス（JPA編）" href="DataAccessJpa.html" /><script async src="https://www.googletagmanager.com/gtag/js?id=G-847V2Q99G8"></script>
+<script>
+window.dataLayer = window.dataLayer || [];
+function gtag(){dataLayer.push(arguments);}
+gtag('js', new Date()); gtag('config', 'G-847V2Q99G8');
+</script>
+<script src="../../_static/jquery.treeview.js" type="text/javascript"></script>
 <!-- <link href='http://fonts.googleapis.com/css?family=Source+Code+Pro|Open+Sans:300italic,400italic,700italic,400,300,700' rel='stylesheet' type='text/css'> -->
 <link href="../../_static/solarized-dark.css" rel="stylesheet">
 <link href="../../_static/jquery.treeview.css" rel="stylesheet">
@@ -129,10 +135,6 @@
             
   <div class="section" id="id1">
 <h1>6.4. 排他制御<a class="headerlink" href="#id1" title="Permalink to this headline">¶</a></h1>
-<div class="admonition caution">
-  <p class="first admonition-title">Caution</p>
-  <p><strong>本バージョンの内容は既に古くなっています</strong>。最新のガイドラインは<a href="http://terasolunaorg.github.io/guideline/">こちら</a>からご参照ください。</p>
-</div>
 <div class="contents local topic" id="id2">
 <p class="topic-title">目次</p>
 <ul class="simple">

--- a/guideline/5.6.0.SP1.RELEASE/ja/ArchitectureInDetail/DataAccessDetail/index.html
+++ b/guideline/5.6.0.SP1.RELEASE/ja/ArchitectureInDetail/DataAccessDetail/index.html
@@ -22,7 +22,13 @@
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />
     <link rel="next" title="6.1. データベースアクセス（共通編）" href="DataAccessCommon.html" />
-    <link rel="prev" title="5.3. SOAP Web Service（サーバ/クライアント）" href="../WebServiceDetail/SOAP.html" /><script src="../../_static/jquery.treeview.js" type="text/javascript"></script>
+    <link rel="prev" title="5.3. SOAP Web Service（サーバ/クライアント）" href="../WebServiceDetail/SOAP.html" /><script async src="https://www.googletagmanager.com/gtag/js?id=G-847V2Q99G8"></script>
+<script>
+window.dataLayer = window.dataLayer || [];
+function gtag(){dataLayer.push(arguments);}
+gtag('js', new Date()); gtag('config', 'G-847V2Q99G8');
+</script>
+<script src="../../_static/jquery.treeview.js" type="text/javascript"></script>
 <!-- <link href='http://fonts.googleapis.com/css?family=Source+Code+Pro|Open+Sans:300italic,400italic,700italic,400,300,700' rel='stylesheet' type='text/css'> -->
 <link href="../../_static/solarized-dark.css" rel="stylesheet">
 <link href="../../_static/jquery.treeview.css" rel="stylesheet">
@@ -80,10 +86,6 @@
             
   <div class="section" id="id1">
 <h1>6. データアクセス<a class="headerlink" href="#id1" title="Permalink to this headline">¶</a></h1>
-<div class="admonition caution">
-  <p class="first admonition-title">Caution</p>
-  <p><strong>本バージョンの内容は既に古くなっています</strong>。最新のガイドラインは<a href="http://terasolunaorg.github.io/guideline/">こちら</a>からご参照ください。</p>
-</div>
 <p>本ガイドラインで想定しているアーキテクチャについて説明する。</p>
 <div class="toctree-wrapper compound">
 <ul>

--- a/guideline/5.6.0.SP1.RELEASE/ja/ArchitectureInDetail/GeneralFuncDetail/DateAndTime.html
+++ b/guideline/5.6.0.SP1.RELEASE/ja/ArchitectureInDetail/GeneralFuncDetail/DateAndTime.html
@@ -22,7 +22,13 @@
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />
     <link rel="next" title="7.4. 日付操作(Joda Time)" href="JodaTime.html" />
-    <link rel="prev" title="7.2. プロパティ管理" href="PropertyManagement.html" /><script src="../../_static/jquery.treeview.js" type="text/javascript"></script>
+    <link rel="prev" title="7.2. プロパティ管理" href="PropertyManagement.html" /><script async src="https://www.googletagmanager.com/gtag/js?id=G-847V2Q99G8"></script>
+<script>
+window.dataLayer = window.dataLayer || [];
+function gtag(){dataLayer.push(arguments);}
+gtag('js', new Date()); gtag('config', 'G-847V2Q99G8');
+</script>
+<script src="../../_static/jquery.treeview.js" type="text/javascript"></script>
 <!-- <link href='http://fonts.googleapis.com/css?family=Source+Code+Pro|Open+Sans:300italic,400italic,700italic,400,300,700' rel='stylesheet' type='text/css'> -->
 <link href="../../_static/solarized-dark.css" rel="stylesheet">
 <link href="../../_static/jquery.treeview.css" rel="stylesheet">
@@ -125,10 +131,6 @@
             
   <div class="section" id="jsr-310-date-and-time-api">
 <h1>7.3. 日付操作(JSR-310 Date and Time API)<a class="headerlink" href="#jsr-310-date-and-time-api" title="Permalink to this headline">¶</a></h1>
-<div class="admonition caution">
-  <p class="first admonition-title">Caution</p>
-  <p><strong>本バージョンの内容は既に古くなっています</strong>。最新のガイドラインは<a href="http://terasolunaorg.github.io/guideline/">こちら</a>からご参照ください。</p>
-</div>
 <div class="contents local topic" id="id1">
 <p class="topic-title">目次</p>
 <ul class="simple">

--- a/guideline/5.6.0.SP1.RELEASE/ja/ArchitectureInDetail/GeneralFuncDetail/Dozer.html
+++ b/guideline/5.6.0.SP1.RELEASE/ja/ArchitectureInDetail/GeneralFuncDetail/Dozer.html
@@ -22,7 +22,13 @@
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />
     <link rel="next" title="8. メッセージ連携" href="../MessagingDetail/index.html" />
-    <link rel="prev" title="7.6. 文字列処理" href="StringProcessing.html" /><script src="../../_static/jquery.treeview.js" type="text/javascript"></script>
+    <link rel="prev" title="7.6. 文字列処理" href="StringProcessing.html" /><script async src="https://www.googletagmanager.com/gtag/js?id=G-847V2Q99G8"></script>
+<script>
+window.dataLayer = window.dataLayer || [];
+function gtag(){dataLayer.push(arguments);}
+gtag('js', new Date()); gtag('config', 'G-847V2Q99G8');
+</script>
+<script src="../../_static/jquery.treeview.js" type="text/javascript"></script>
 <!-- <link href='http://fonts.googleapis.com/css?family=Source+Code+Pro|Open+Sans:300italic,400italic,700italic,400,300,700' rel='stylesheet' type='text/css'> -->
 <link href="../../_static/solarized-dark.css" rel="stylesheet">
 <link href="../../_static/jquery.treeview.css" rel="stylesheet">
@@ -111,10 +117,6 @@
             
   <div class="section" id="bean-dozer">
 <h1>7.7. Beanマッピング(Dozer)<a class="headerlink" href="#bean-dozer" title="Permalink to this headline">¶</a></h1>
-<div class="admonition caution">
-  <p class="first admonition-title">Caution</p>
-  <p><strong>本バージョンの内容は既に古くなっています</strong>。最新のガイドラインは<a href="http://terasolunaorg.github.io/guideline/">こちら</a>からご参照ください。</p>
-</div>
 <div class="contents local topic" id="id1">
 <p class="topic-title">目次</p>
 <ul class="simple">

--- a/guideline/5.6.0.SP1.RELEASE/ja/ArchitectureInDetail/GeneralFuncDetail/JodaTime.html
+++ b/guideline/5.6.0.SP1.RELEASE/ja/ArchitectureInDetail/GeneralFuncDetail/JodaTime.html
@@ -22,7 +22,13 @@
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />
     <link rel="next" title="7.5. システム時刻" href="SystemDate.html" />
-    <link rel="prev" title="7.3. 日付操作(JSR-310 Date and Time API)" href="DateAndTime.html" /><script src="../../_static/jquery.treeview.js" type="text/javascript"></script>
+    <link rel="prev" title="7.3. 日付操作(JSR-310 Date and Time API)" href="DateAndTime.html" /><script async src="https://www.googletagmanager.com/gtag/js?id=G-847V2Q99G8"></script>
+<script>
+window.dataLayer = window.dataLayer || [];
+function gtag(){dataLayer.push(arguments);}
+gtag('js', new Date()); gtag('config', 'G-847V2Q99G8');
+</script>
+<script src="../../_static/jquery.treeview.js" type="text/javascript"></script>
 <!-- <link href='http://fonts.googleapis.com/css?family=Source+Code+Pro|Open+Sans:300italic,400italic,700italic,400,300,700' rel='stylesheet' type='text/css'> -->
 <link href="../../_static/solarized-dark.css" rel="stylesheet">
 <link href="../../_static/jquery.treeview.css" rel="stylesheet">
@@ -128,10 +134,6 @@
             
   <div class="section" id="joda-time">
 <h1>7.4. 日付操作(Joda Time)<a class="headerlink" href="#joda-time" title="Permalink to this headline">¶</a></h1>
-<div class="admonition caution">
-  <p class="first admonition-title">Caution</p>
-  <p><strong>本バージョンの内容は既に古くなっています</strong>。最新のガイドラインは<a href="http://terasolunaorg.github.io/guideline/">こちら</a>からご参照ください。</p>
-</div>
 <div class="contents local topic" id="id1">
 <p class="topic-title">目次</p>
 <ul class="simple">

--- a/guideline/5.6.0.SP1.RELEASE/ja/ArchitectureInDetail/GeneralFuncDetail/Logging.html
+++ b/guideline/5.6.0.SP1.RELEASE/ja/ArchitectureInDetail/GeneralFuncDetail/Logging.html
@@ -22,7 +22,13 @@
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />
     <link rel="next" title="7.2. プロパティ管理" href="PropertyManagement.html" />
-    <link rel="prev" title="7. アプリケーション形態に依存しない汎用機能" href="index.html" /><script src="../../_static/jquery.treeview.js" type="text/javascript"></script>
+    <link rel="prev" title="7. アプリケーション形態に依存しない汎用機能" href="index.html" /><script async src="https://www.googletagmanager.com/gtag/js?id=G-847V2Q99G8"></script>
+<script>
+window.dataLayer = window.dataLayer || [];
+function gtag(){dataLayer.push(arguments);}
+gtag('js', new Date()); gtag('config', 'G-847V2Q99G8');
+</script>
+<script src="../../_static/jquery.treeview.js" type="text/javascript"></script>
 <!-- <link href='http://fonts.googleapis.com/css?family=Source+Code+Pro|Open+Sans:300italic,400italic,700italic,400,300,700' rel='stylesheet' type='text/css'> -->
 <link href="../../_static/solarized-dark.css" rel="stylesheet">
 <link href="../../_static/jquery.treeview.css" rel="stylesheet">
@@ -127,10 +133,6 @@
             
   <div class="section" id="id1">
 <h1>7.1. ロギング<a class="headerlink" href="#id1" title="Permalink to this headline">¶</a></h1>
-<div class="admonition caution">
-  <p class="first admonition-title">Caution</p>
-  <p><strong>本バージョンの内容は既に古くなっています</strong>。最新のガイドラインは<a href="http://terasolunaorg.github.io/guideline/">こちら</a>からご参照ください。</p>
-</div>
 <div class="contents local topic" id="contents">
 <ul class="simple">
 <li><a class="reference internal" href="#overview" id="id17">Overview</a><ul>

--- a/guideline/5.6.0.SP1.RELEASE/ja/ArchitectureInDetail/GeneralFuncDetail/PropertyManagement.html
+++ b/guideline/5.6.0.SP1.RELEASE/ja/ArchitectureInDetail/GeneralFuncDetail/PropertyManagement.html
@@ -22,7 +22,13 @@
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />
     <link rel="next" title="7.3. 日付操作(JSR-310 Date and Time API)" href="DateAndTime.html" />
-    <link rel="prev" title="7.1. ロギング" href="Logging.html" /><script src="../../_static/jquery.treeview.js" type="text/javascript"></script>
+    <link rel="prev" title="7.1. ロギング" href="Logging.html" /><script async src="https://www.googletagmanager.com/gtag/js?id=G-847V2Q99G8"></script>
+<script>
+window.dataLayer = window.dataLayer || [];
+function gtag(){dataLayer.push(arguments);}
+gtag('js', new Date()); gtag('config', 'G-847V2Q99G8');
+</script>
+<script src="../../_static/jquery.treeview.js" type="text/javascript"></script>
 <!-- <link href='http://fonts.googleapis.com/css?family=Source+Code+Pro|Open+Sans:300italic,400italic,700italic,400,300,700' rel='stylesheet' type='text/css'> -->
 <link href="../../_static/solarized-dark.css" rel="stylesheet">
 <link href="../../_static/jquery.treeview.css" rel="stylesheet">
@@ -99,10 +105,6 @@
             
   <div class="section" id="id1">
 <h1>7.2. プロパティ管理<a class="headerlink" href="#id1" title="Permalink to this headline">¶</a></h1>
-<div class="admonition caution">
-  <p class="first admonition-title">Caution</p>
-  <p><strong>本バージョンの内容は既に古くなっています</strong>。最新のガイドラインは<a href="http://terasolunaorg.github.io/guideline/">こちら</a>からご参照ください。</p>
-</div>
 <div class="contents local topic" id="id2">
 <p class="topic-title">目次</p>
 <ul class="simple">

--- a/guideline/5.6.0.SP1.RELEASE/ja/ArchitectureInDetail/GeneralFuncDetail/StringProcessing.html
+++ b/guideline/5.6.0.SP1.RELEASE/ja/ArchitectureInDetail/GeneralFuncDetail/StringProcessing.html
@@ -22,7 +22,13 @@
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />
     <link rel="next" title="7.7. Beanマッピング(Dozer)" href="Dozer.html" />
-    <link rel="prev" title="7.5. システム時刻" href="SystemDate.html" /><script src="../../_static/jquery.treeview.js" type="text/javascript"></script>
+    <link rel="prev" title="7.5. システム時刻" href="SystemDate.html" /><script async src="https://www.googletagmanager.com/gtag/js?id=G-847V2Q99G8"></script>
+<script>
+window.dataLayer = window.dataLayer || [];
+function gtag(){dataLayer.push(arguments);}
+gtag('js', new Date()); gtag('config', 'G-847V2Q99G8');
+</script>
+<script src="../../_static/jquery.treeview.js" type="text/javascript"></script>
 <!-- <link href='http://fonts.googleapis.com/css?family=Source+Code+Pro|Open+Sans:300italic,400italic,700italic,400,300,700' rel='stylesheet' type='text/css'> -->
 <link href="../../_static/solarized-dark.css" rel="stylesheet">
 <link href="../../_static/jquery.treeview.css" rel="stylesheet">
@@ -117,10 +123,6 @@
             
   <div class="section" id="id1">
 <h1>7.6. 文字列処理<a class="headerlink" href="#id1" title="Permalink to this headline">¶</a></h1>
-<div class="admonition caution">
-  <p class="first admonition-title">Caution</p>
-  <p><strong>本バージョンの内容は既に古くなっています</strong>。最新のガイドラインは<a href="http://terasolunaorg.github.io/guideline/">こちら</a>からご参照ください。</p>
-</div>
 <div class="contents local topic" id="id2">
 <p class="topic-title">目次</p>
 <ul class="simple">

--- a/guideline/5.6.0.SP1.RELEASE/ja/ArchitectureInDetail/GeneralFuncDetail/SystemDate.html
+++ b/guideline/5.6.0.SP1.RELEASE/ja/ArchitectureInDetail/GeneralFuncDetail/SystemDate.html
@@ -22,7 +22,13 @@
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />
     <link rel="next" title="7.6. 文字列処理" href="StringProcessing.html" />
-    <link rel="prev" title="7.4. 日付操作(Joda Time)" href="JodaTime.html" /><script src="../../_static/jquery.treeview.js" type="text/javascript"></script>
+    <link rel="prev" title="7.4. 日付操作(Joda Time)" href="JodaTime.html" /><script async src="https://www.googletagmanager.com/gtag/js?id=G-847V2Q99G8"></script>
+<script>
+window.dataLayer = window.dataLayer || [];
+function gtag(){dataLayer.push(arguments);}
+gtag('js', new Date()); gtag('config', 'G-847V2Q99G8');
+</script>
+<script src="../../_static/jquery.treeview.js" type="text/javascript"></script>
 <!-- <link href='http://fonts.googleapis.com/css?family=Source+Code+Pro|Open+Sans:300italic,400italic,700italic,400,300,700' rel='stylesheet' type='text/css'> -->
 <link href="../../_static/solarized-dark.css" rel="stylesheet">
 <link href="../../_static/jquery.treeview.css" rel="stylesheet">
@@ -116,10 +122,6 @@
             
   <div class="section" id="id1">
 <h1>7.5. システム時刻<a class="headerlink" href="#id1" title="Permalink to this headline">¶</a></h1>
-<div class="admonition caution">
-  <p class="first admonition-title">Caution</p>
-  <p><strong>本バージョンの内容は既に古くなっています</strong>。最新のガイドラインは<a href="http://terasolunaorg.github.io/guideline/">こちら</a>からご参照ください。</p>
-</div>
 <div class="contents local topic" id="id2">
 <p class="topic-title">目次</p>
 <ul class="simple">

--- a/guideline/5.6.0.SP1.RELEASE/ja/ArchitectureInDetail/GeneralFuncDetail/index.html
+++ b/guideline/5.6.0.SP1.RELEASE/ja/ArchitectureInDetail/GeneralFuncDetail/index.html
@@ -22,7 +22,13 @@
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />
     <link rel="next" title="7.1. ロギング" href="Logging.html" />
-    <link rel="prev" title="6.4. 排他制御" href="../DataAccessDetail/ExclusionControl.html" /><script src="../../_static/jquery.treeview.js" type="text/javascript"></script>
+    <link rel="prev" title="6.4. 排他制御" href="../DataAccessDetail/ExclusionControl.html" /><script async src="https://www.googletagmanager.com/gtag/js?id=G-847V2Q99G8"></script>
+<script>
+window.dataLayer = window.dataLayer || [];
+function gtag(){dataLayer.push(arguments);}
+gtag('js', new Date()); gtag('config', 'G-847V2Q99G8');
+</script>
+<script src="../../_static/jquery.treeview.js" type="text/javascript"></script>
 <!-- <link href='http://fonts.googleapis.com/css?family=Source+Code+Pro|Open+Sans:300italic,400italic,700italic,400,300,700' rel='stylesheet' type='text/css'> -->
 <link href="../../_static/solarized-dark.css" rel="stylesheet">
 <link href="../../_static/jquery.treeview.css" rel="stylesheet">
@@ -80,10 +86,6 @@
             
   <div class="section" id="id1">
 <h1>7. アプリケーション形態に依存しない汎用機能<a class="headerlink" href="#id1" title="Permalink to this headline">¶</a></h1>
-<div class="admonition caution">
-  <p class="first admonition-title">Caution</p>
-  <p><strong>本バージョンの内容は既に古くなっています</strong>。最新のガイドラインは<a href="http://terasolunaorg.github.io/guideline/">こちら</a>からご参照ください。</p>
-</div>
 <div class="toctree-wrapper compound">
 <ul>
 <li class="toctree-l1"><a class="reference internal" href="Logging.html">7.1. ロギング</a></li>

--- a/guideline/5.6.0.SP1.RELEASE/ja/ArchitectureInDetail/MessagingDetail/Email.html
+++ b/guideline/5.6.0.SP1.RELEASE/ja/ArchitectureInDetail/MessagingDetail/Email.html
@@ -22,7 +22,13 @@
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />
     <link rel="next" title="8.2. JMS(Java Message Service)" href="JMS.html" />
-    <link rel="prev" title="8. メッセージ連携" href="index.html" /><script src="../../_static/jquery.treeview.js" type="text/javascript"></script>
+    <link rel="prev" title="8. メッセージ連携" href="index.html" /><script async src="https://www.googletagmanager.com/gtag/js?id=G-847V2Q99G8"></script>
+<script>
+window.dataLayer = window.dataLayer || [];
+function gtag(){dataLayer.push(arguments);}
+gtag('js', new Date()); gtag('config', 'G-847V2Q99G8');
+</script>
+<script src="../../_static/jquery.treeview.js" type="text/javascript"></script>
 <!-- <link href='http://fonts.googleapis.com/css?family=Source+Code+Pro|Open+Sans:300italic,400italic,700italic,400,300,700' rel='stylesheet' type='text/css'> -->
 <link href="../../_static/solarized-dark.css" rel="stylesheet">
 <link href="../../_static/jquery.treeview.css" rel="stylesheet">
@@ -130,10 +136,6 @@
             
   <div class="section" id="e-mail-smtp">
 <h1>8.1. E-mail送信(SMTP)<a class="headerlink" href="#e-mail-smtp" title="Permalink to this headline">¶</a></h1>
-<div class="admonition caution">
-  <p class="first admonition-title">Caution</p>
-  <p><strong>本バージョンの内容は既に古くなっています</strong>。最新のガイドラインは<a href="http://terasolunaorg.github.io/guideline/">こちら</a>からご参照ください。</p>
-</div>
 <div class="contents local topic" id="id1">
 <p class="topic-title">目次</p>
 <ul class="simple">

--- a/guideline/5.6.0.SP1.RELEASE/ja/ArchitectureInDetail/MessagingDetail/JMS.html
+++ b/guideline/5.6.0.SP1.RELEASE/ja/ArchitectureInDetail/MessagingDetail/JMS.html
@@ -22,7 +22,13 @@
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />
     <link rel="next" title="9. セキュリティ対策" href="../../Security/index.html" />
-    <link rel="prev" title="8.1. E-mail送信(SMTP)" href="Email.html" /><script src="../../_static/jquery.treeview.js" type="text/javascript"></script>
+    <link rel="prev" title="8.1. E-mail送信(SMTP)" href="Email.html" /><script async src="https://www.googletagmanager.com/gtag/js?id=G-847V2Q99G8"></script>
+<script>
+window.dataLayer = window.dataLayer || [];
+function gtag(){dataLayer.push(arguments);}
+gtag('js', new Date()); gtag('config', 'G-847V2Q99G8');
+</script>
+<script src="../../_static/jquery.treeview.js" type="text/javascript"></script>
 <!-- <link href='http://fonts.googleapis.com/css?family=Source+Code+Pro|Open+Sans:300italic,400italic,700italic,400,300,700' rel='stylesheet' type='text/css'> -->
 <link href="../../_static/solarized-dark.css" rel="stylesheet">
 <link href="../../_static/jquery.treeview.css" rel="stylesheet">
@@ -138,10 +144,6 @@
             
   <div class="section" id="jms-java-message-service">
 <h1>8.2. JMS(Java Message Service)<a class="headerlink" href="#jms-java-message-service" title="Permalink to this headline">¶</a></h1>
-<div class="admonition caution">
-  <p class="first admonition-title">Caution</p>
-  <p><strong>本バージョンの内容は既に古くなっています</strong>。最新のガイドラインは<a href="http://terasolunaorg.github.io/guideline/">こちら</a>からご参照ください。</p>
-</div>
 <div class="contents local topic" id="id1">
 <p class="topic-title">目次</p>
 <ul class="simple">

--- a/guideline/5.6.0.SP1.RELEASE/ja/ArchitectureInDetail/MessagingDetail/index.html
+++ b/guideline/5.6.0.SP1.RELEASE/ja/ArchitectureInDetail/MessagingDetail/index.html
@@ -22,7 +22,13 @@
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />
     <link rel="next" title="8.1. E-mail送信(SMTP)" href="Email.html" />
-    <link rel="prev" title="7.7. Beanマッピング(Dozer)" href="../GeneralFuncDetail/Dozer.html" /><script src="../../_static/jquery.treeview.js" type="text/javascript"></script>
+    <link rel="prev" title="7.7. Beanマッピング(Dozer)" href="../GeneralFuncDetail/Dozer.html" /><script async src="https://www.googletagmanager.com/gtag/js?id=G-847V2Q99G8"></script>
+<script>
+window.dataLayer = window.dataLayer || [];
+function gtag(){dataLayer.push(arguments);}
+gtag('js', new Date()); gtag('config', 'G-847V2Q99G8');
+</script>
+<script src="../../_static/jquery.treeview.js" type="text/javascript"></script>
 <!-- <link href='http://fonts.googleapis.com/css?family=Source+Code+Pro|Open+Sans:300italic,400italic,700italic,400,300,700' rel='stylesheet' type='text/css'> -->
 <link href="../../_static/solarized-dark.css" rel="stylesheet">
 <link href="../../_static/jquery.treeview.css" rel="stylesheet">
@@ -80,10 +86,6 @@
             
   <div class="section" id="id1">
 <h1>8. メッセージ連携<a class="headerlink" href="#id1" title="Permalink to this headline">¶</a></h1>
-<div class="admonition caution">
-  <p class="first admonition-title">Caution</p>
-  <p><strong>本バージョンの内容は既に古くなっています</strong>。最新のガイドラインは<a href="http://terasolunaorg.github.io/guideline/">こちら</a>からご参照ください。</p>
-</div>
 <div class="toctree-wrapper compound">
 <ul>
 <li class="toctree-l1"><a class="reference internal" href="Email.html">8.1. E-mail送信(SMTP)</a></li>

--- a/guideline/5.6.0.SP1.RELEASE/ja/ArchitectureInDetail/WebApplicationDetail/Ajax.html
+++ b/guideline/5.6.0.SP1.RELEASE/ja/ArchitectureInDetail/WebApplicationDetail/Ajax.html
@@ -22,7 +22,13 @@
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />
     <link rel="next" title="4.14. ヘルスチェック" href="HealthCheck.html" />
-    <link rel="prev" title="4.12. 共通ライブラリが提供するJSP Tag Library と EL Functions" href="TagLibAndELFunctions.html" /><script src="../../_static/jquery.treeview.js" type="text/javascript"></script>
+    <link rel="prev" title="4.12. 共通ライブラリが提供するJSP Tag Library と EL Functions" href="TagLibAndELFunctions.html" /><script async src="https://www.googletagmanager.com/gtag/js?id=G-847V2Q99G8"></script>
+<script>
+window.dataLayer = window.dataLayer || [];
+function gtag(){dataLayer.push(arguments);}
+gtag('js', new Date()); gtag('config', 'G-847V2Q99G8');
+</script>
+<script src="../../_static/jquery.treeview.js" type="text/javascript"></script>
 <!-- <link href='http://fonts.googleapis.com/css?family=Source+Code+Pro|Open+Sans:300italic,400italic,700italic,400,300,700' rel='stylesheet' type='text/css'> -->
 <link href="../../_static/solarized-dark.css" rel="stylesheet">
 <link href="../../_static/jquery.treeview.css" rel="stylesheet">
@@ -114,10 +120,6 @@
             
   <div class="section" id="ajax">
 <h1>4.13. Ajax<a class="headerlink" href="#ajax" title="Permalink to this headline">¶</a></h1>
-<div class="admonition caution">
-  <p class="first admonition-title">Caution</p>
-  <p><strong>本バージョンの内容は既に古くなっています</strong>。最新のガイドラインは<a href="http://terasolunaorg.github.io/guideline/">こちら</a>からご参照ください。</p>
-</div>
 <div class="contents local topic" id="id1">
 <p class="topic-title">目次</p>
 <ul class="simple">

--- a/guideline/5.6.0.SP1.RELEASE/ja/ArchitectureInDetail/WebApplicationDetail/Codelist.html
+++ b/guideline/5.6.0.SP1.RELEASE/ja/ArchitectureInDetail/WebApplicationDetail/Codelist.html
@@ -22,7 +22,13 @@
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />
     <link rel="next" title="4.9. ファイルアップロード" href="FileUpload.html" />
-    <link rel="prev" title="4.7. 国際化" href="Internationalization.html" /><script src="../../_static/jquery.treeview.js" type="text/javascript"></script>
+    <link rel="prev" title="4.7. 国際化" href="Internationalization.html" /><script async src="https://www.googletagmanager.com/gtag/js?id=G-847V2Q99G8"></script>
+<script>
+window.dataLayer = window.dataLayer || [];
+function gtag(){dataLayer.push(arguments);}
+gtag('js', new Date()); gtag('config', 'G-847V2Q99G8');
+</script>
+<script src="../../_static/jquery.treeview.js" type="text/javascript"></script>
 <!-- <link href='http://fonts.googleapis.com/css?family=Source+Code+Pro|Open+Sans:300italic,400italic,700italic,400,300,700' rel='stylesheet' type='text/css'> -->
 <link href="../../_static/solarized-dark.css" rel="stylesheet">
 <link href="../../_static/jquery.treeview.css" rel="stylesheet">
@@ -151,10 +157,6 @@
             
   <div class="section" id="id1">
 <h1>4.8. コードリスト<a class="headerlink" href="#id1" title="Permalink to this headline">¶</a></h1>
-<div class="admonition caution">
-  <p class="first admonition-title">Caution</p>
-  <p><strong>本バージョンの内容は既に古くなっています</strong>。最新のガイドラインは<a href="http://terasolunaorg.github.io/guideline/">こちら</a>からご参照ください。</p>
-</div>
 <div class="contents local topic" id="id2">
 <p class="topic-title">目次</p>
 <ul class="simple">

--- a/guideline/5.6.0.SP1.RELEASE/ja/ArchitectureInDetail/WebApplicationDetail/DoubleSubmitProtection.html
+++ b/guideline/5.6.0.SP1.RELEASE/ja/ArchitectureInDetail/WebApplicationDetail/DoubleSubmitProtection.html
@@ -22,7 +22,13 @@
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />
     <link rel="next" title="4.6. メッセージ管理" href="MessageManagement.html" />
-    <link rel="prev" title="4.4. ページネーション" href="Pagination.html" /><script src="../../_static/jquery.treeview.js" type="text/javascript"></script>
+    <link rel="prev" title="4.4. ページネーション" href="Pagination.html" /><script async src="https://www.googletagmanager.com/gtag/js?id=G-847V2Q99G8"></script>
+<script>
+window.dataLayer = window.dataLayer || [];
+function gtag(){dataLayer.push(arguments);}
+gtag('js', new Date()); gtag('config', 'G-847V2Q99G8');
+</script>
+<script src="../../_static/jquery.treeview.js" type="text/javascript"></script>
 <!-- <link href='http://fonts.googleapis.com/css?family=Source+Code+Pro|Open+Sans:300italic,400italic,700italic,400,300,700' rel='stylesheet' type='text/css'> -->
 <link href="../../_static/solarized-dark.css" rel="stylesheet">
 <link href="../../_static/jquery.treeview.css" rel="stylesheet">
@@ -142,10 +148,6 @@
             
   <div class="section" id="id1">
 <h1>4.5. 二重送信防止<a class="headerlink" href="#id1" title="Permalink to this headline">¶</a></h1>
-<div class="admonition caution">
-  <p class="first admonition-title">Caution</p>
-  <p><strong>本バージョンの内容は既に古くなっています</strong>。最新のガイドラインは<a href="http://terasolunaorg.github.io/guideline/">こちら</a>からご参照ください。</p>
-</div>
 <div class="contents local topic" id="id2">
 <p class="topic-title">目次</p>
 <ul class="simple">

--- a/guideline/5.6.0.SP1.RELEASE/ja/ArchitectureInDetail/WebApplicationDetail/ExceptionHandling.html
+++ b/guideline/5.6.0.SP1.RELEASE/ja/ArchitectureInDetail/WebApplicationDetail/ExceptionHandling.html
@@ -22,7 +22,13 @@
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />
     <link rel="next" title="4.3. セッション管理" href="SessionManagement.html" />
-    <link rel="prev" title="4.1. 入力チェック" href="Validation.html" /><script src="../../_static/jquery.treeview.js" type="text/javascript"></script>
+    <link rel="prev" title="4.1. 入力チェック" href="Validation.html" /><script async src="https://www.googletagmanager.com/gtag/js?id=G-847V2Q99G8"></script>
+<script>
+window.dataLayer = window.dataLayer || [];
+function gtag(){dataLayer.push(arguments);}
+gtag('js', new Date()); gtag('config', 'G-847V2Q99G8');
+</script>
+<script src="../../_static/jquery.treeview.js" type="text/javascript"></script>
 <!-- <link href='http://fonts.googleapis.com/css?family=Source+Code+Pro|Open+Sans:300italic,400italic,700italic,400,300,700' rel='stylesheet' type='text/css'> -->
 <link href="../../_static/solarized-dark.css" rel="stylesheet">
 <link href="../../_static/jquery.treeview.css" rel="stylesheet">
@@ -165,10 +171,6 @@
             
   <div class="section" id="id1">
 <h1>4.2. 例外ハンドリング<a class="headerlink" href="#id1" title="Permalink to this headline">¶</a></h1>
-<div class="admonition caution">
-  <p class="first admonition-title">Caution</p>
-  <p><strong>本バージョンの内容は既に古くなっています</strong>。最新のガイドラインは<a href="http://terasolunaorg.github.io/guideline/">こちら</a>からご参照ください。</p>
-</div>
 <div class="contents local topic" id="id2">
 <p class="topic-title">目次</p>
 <ul class="simple">

--- a/guideline/5.6.0.SP1.RELEASE/ja/ArchitectureInDetail/WebApplicationDetail/FileDownload.html
+++ b/guideline/5.6.0.SP1.RELEASE/ja/ArchitectureInDetail/WebApplicationDetail/FileDownload.html
@@ -22,7 +22,13 @@
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />
     <link rel="next" title="4.11. Tilesによる画面レイアウト" href="TilesLayout.html" />
-    <link rel="prev" title="4.9. ファイルアップロード" href="FileUpload.html" /><script src="../../_static/jquery.treeview.js" type="text/javascript"></script>
+    <link rel="prev" title="4.9. ファイルアップロード" href="FileUpload.html" /><script async src="https://www.googletagmanager.com/gtag/js?id=G-847V2Q99G8"></script>
+<script>
+window.dataLayer = window.dataLayer || [];
+function gtag(){dataLayer.push(arguments);}
+gtag('js', new Date()); gtag('config', 'G-847V2Q99G8');
+</script>
+<script src="../../_static/jquery.treeview.js" type="text/javascript"></script>
 <!-- <link href='http://fonts.googleapis.com/css?family=Source+Code+Pro|Open+Sans:300italic,400italic,700italic,400,300,700' rel='stylesheet' type='text/css'> -->
 <link href="../../_static/solarized-dark.css" rel="stylesheet">
 <link href="../../_static/jquery.treeview.css" rel="stylesheet">
@@ -110,10 +116,6 @@
             
   <div class="section" id="id1">
 <h1>4.10. ファイルダウンロード<a class="headerlink" href="#id1" title="Permalink to this headline">¶</a></h1>
-<div class="admonition caution">
-  <p class="first admonition-title">Caution</p>
-  <p><strong>本バージョンの内容は既に古くなっています</strong>。最新のガイドラインは<a href="http://terasolunaorg.github.io/guideline/">こちら</a>からご参照ください。</p>
-</div>
 <div class="contents local topic" id="id2">
 <p class="topic-title">目次</p>
 <ul class="simple">

--- a/guideline/5.6.0.SP1.RELEASE/ja/ArchitectureInDetail/WebApplicationDetail/FileUpload.html
+++ b/guideline/5.6.0.SP1.RELEASE/ja/ArchitectureInDetail/WebApplicationDetail/FileUpload.html
@@ -22,7 +22,13 @@
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />
     <link rel="next" title="4.10. ファイルダウンロード" href="FileDownload.html" />
-    <link rel="prev" title="4.8. コードリスト" href="Codelist.html" /><script src="../../_static/jquery.treeview.js" type="text/javascript"></script>
+    <link rel="prev" title="4.8. コードリスト" href="Codelist.html" /><script async src="https://www.googletagmanager.com/gtag/js?id=G-847V2Q99G8"></script>
+<script>
+window.dataLayer = window.dataLayer || [];
+function gtag(){dataLayer.push(arguments);}
+gtag('js', new Date()); gtag('config', 'G-847V2Q99G8');
+</script>
+<script src="../../_static/jquery.treeview.js" type="text/javascript"></script>
 <!-- <link href='http://fonts.googleapis.com/css?family=Source+Code+Pro|Open+Sans:300italic,400italic,700italic,400,300,700' rel='stylesheet' type='text/css'> -->
 <link href="../../_static/solarized-dark.css" rel="stylesheet">
 <link href="../../_static/jquery.treeview.css" rel="stylesheet">
@@ -151,10 +157,6 @@
             
   <div class="section" id="id1">
 <h1>4.9. ファイルアップロード<a class="headerlink" href="#id1" title="Permalink to this headline">¶</a></h1>
-<div class="admonition caution">
-  <p class="first admonition-title">Caution</p>
-  <p><strong>本バージョンの内容は既に古くなっています</strong>。最新のガイドラインは<a href="http://terasolunaorg.github.io/guideline/">こちら</a>からご参照ください。</p>
-</div>
 <div class="contents local topic" id="id2">
 <p class="topic-title">目次</p>
 <ul class="simple">

--- a/guideline/5.6.0.SP1.RELEASE/ja/ArchitectureInDetail/WebApplicationDetail/HealthCheck.html
+++ b/guideline/5.6.0.SP1.RELEASE/ja/ArchitectureInDetail/WebApplicationDetail/HealthCheck.html
@@ -22,7 +22,13 @@
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />
     <link rel="next" title="5. Web Service" href="../WebServiceDetail/index.html" />
-    <link rel="prev" title="4.13. Ajax" href="Ajax.html" /><script src="../../_static/jquery.treeview.js" type="text/javascript"></script>
+    <link rel="prev" title="4.13. Ajax" href="Ajax.html" /><script async src="https://www.googletagmanager.com/gtag/js?id=G-847V2Q99G8"></script>
+<script>
+window.dataLayer = window.dataLayer || [];
+function gtag(){dataLayer.push(arguments);}
+gtag('js', new Date()); gtag('config', 'G-847V2Q99G8');
+</script>
+<script src="../../_static/jquery.treeview.js" type="text/javascript"></script>
 <!-- <link href='http://fonts.googleapis.com/css?family=Source+Code+Pro|Open+Sans:300italic,400italic,700italic,400,300,700' rel='stylesheet' type='text/css'> -->
 <link href="../../_static/solarized-dark.css" rel="stylesheet">
 <link href="../../_static/jquery.treeview.css" rel="stylesheet">
@@ -111,10 +117,6 @@
             
   <div class="section" id="id1">
 <h1>4.14. ヘルスチェック<a class="headerlink" href="#id1" title="Permalink to this headline">¶</a></h1>
-<div class="admonition caution">
-  <p class="first admonition-title">Caution</p>
-  <p><strong>本バージョンの内容は既に古くなっています</strong>。最新のガイドラインは<a href="http://terasolunaorg.github.io/guideline/">こちら</a>からご参照ください。</p>
-</div>
 <div class="contents local topic" id="id2">
 <p class="topic-title">目次</p>
 <ul class="simple">

--- a/guideline/5.6.0.SP1.RELEASE/ja/ArchitectureInDetail/WebApplicationDetail/Internationalization.html
+++ b/guideline/5.6.0.SP1.RELEASE/ja/ArchitectureInDetail/WebApplicationDetail/Internationalization.html
@@ -22,7 +22,13 @@
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />
     <link rel="next" title="4.8. コードリスト" href="Codelist.html" />
-    <link rel="prev" title="4.6. メッセージ管理" href="MessageManagement.html" /><script src="../../_static/jquery.treeview.js" type="text/javascript"></script>
+    <link rel="prev" title="4.6. メッセージ管理" href="MessageManagement.html" /><script async src="https://www.googletagmanager.com/gtag/js?id=G-847V2Q99G8"></script>
+<script>
+window.dataLayer = window.dataLayer || [];
+function gtag(){dataLayer.push(arguments);}
+gtag('js', new Date()); gtag('config', 'G-847V2Q99G8');
+</script>
+<script src="../../_static/jquery.treeview.js" type="text/javascript"></script>
 <!-- <link href='http://fonts.googleapis.com/css?family=Source+Code+Pro|Open+Sans:300italic,400italic,700italic,400,300,700' rel='stylesheet' type='text/css'> -->
 <link href="../../_static/solarized-dark.css" rel="stylesheet">
 <link href="../../_static/jquery.treeview.css" rel="stylesheet">
@@ -108,10 +114,6 @@
             
   <div class="section" id="id1">
 <h1>4.7. 国際化<a class="headerlink" href="#id1" title="Permalink to this headline">¶</a></h1>
-<div class="admonition caution">
-  <p class="first admonition-title">Caution</p>
-  <p><strong>本バージョンの内容は既に古くなっています</strong>。最新のガイドラインは<a href="http://terasolunaorg.github.io/guideline/">こちら</a>からご参照ください。</p>
-</div>
 <div class="contents local topic" id="id2">
 <p class="topic-title">目次</p>
 <ul class="simple">

--- a/guideline/5.6.0.SP1.RELEASE/ja/ArchitectureInDetail/WebApplicationDetail/MessageManagement.html
+++ b/guideline/5.6.0.SP1.RELEASE/ja/ArchitectureInDetail/WebApplicationDetail/MessageManagement.html
@@ -22,7 +22,13 @@
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />
     <link rel="next" title="4.7. 国際化" href="Internationalization.html" />
-    <link rel="prev" title="4.5. 二重送信防止" href="DoubleSubmitProtection.html" /><script src="../../_static/jquery.treeview.js" type="text/javascript"></script>
+    <link rel="prev" title="4.5. 二重送信防止" href="DoubleSubmitProtection.html" /><script async src="https://www.googletagmanager.com/gtag/js?id=G-847V2Q99G8"></script>
+<script>
+window.dataLayer = window.dataLayer || [];
+function gtag(){dataLayer.push(arguments);}
+gtag('js', new Date()); gtag('config', 'G-847V2Q99G8');
+</script>
+<script src="../../_static/jquery.treeview.js" type="text/javascript"></script>
 <!-- <link href='http://fonts.googleapis.com/css?family=Source+Code+Pro|Open+Sans:300italic,400italic,700italic,400,300,700' rel='stylesheet' type='text/css'> -->
 <link href="../../_static/solarized-dark.css" rel="stylesheet">
 <link href="../../_static/jquery.treeview.css" rel="stylesheet">
@@ -128,10 +134,6 @@
             
   <div class="section" id="id1">
 <h1>4.6. メッセージ管理<a class="headerlink" href="#id1" title="Permalink to this headline">¶</a></h1>
-<div class="admonition caution">
-  <p class="first admonition-title">Caution</p>
-  <p><strong>本バージョンの内容は既に古くなっています</strong>。最新のガイドラインは<a href="http://terasolunaorg.github.io/guideline/">こちら</a>からご参照ください。</p>
-</div>
 <div class="contents local topic" id="id2">
 <p class="topic-title">目次</p>
 <ul class="simple">

--- a/guideline/5.6.0.SP1.RELEASE/ja/ArchitectureInDetail/WebApplicationDetail/Pagination.html
+++ b/guideline/5.6.0.SP1.RELEASE/ja/ArchitectureInDetail/WebApplicationDetail/Pagination.html
@@ -22,7 +22,13 @@
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />
     <link rel="next" title="4.5. 二重送信防止" href="DoubleSubmitProtection.html" />
-    <link rel="prev" title="4.3. セッション管理" href="SessionManagement.html" /><script src="../../_static/jquery.treeview.js" type="text/javascript"></script>
+    <link rel="prev" title="4.3. セッション管理" href="SessionManagement.html" /><script async src="https://www.googletagmanager.com/gtag/js?id=G-847V2Q99G8"></script>
+<script>
+window.dataLayer = window.dataLayer || [];
+function gtag(){dataLayer.push(arguments);}
+gtag('js', new Date()); gtag('config', 'G-847V2Q99G8');
+</script>
+<script src="../../_static/jquery.treeview.js" type="text/javascript"></script>
 <!-- <link href='http://fonts.googleapis.com/css?family=Source+Code+Pro|Open+Sans:300italic,400italic,700italic,400,300,700' rel='stylesheet' type='text/css'> -->
 <link href="../../_static/solarized-dark.css" rel="stylesheet">
 <link href="../../_static/jquery.treeview.css" rel="stylesheet">
@@ -147,10 +153,6 @@
             
   <div class="section" id="id1">
 <h1>4.4. ページネーション<a class="headerlink" href="#id1" title="Permalink to this headline">¶</a></h1>
-<div class="admonition caution">
-  <p class="first admonition-title">Caution</p>
-  <p><strong>本バージョンの内容は既に古くなっています</strong>。最新のガイドラインは<a href="http://terasolunaorg.github.io/guideline/">こちら</a>からご参照ください。</p>
-</div>
 <div class="contents local topic" id="id2">
 <p class="topic-title">目次</p>
 <ul class="simple">

--- a/guideline/5.6.0.SP1.RELEASE/ja/ArchitectureInDetail/WebApplicationDetail/SessionManagement.html
+++ b/guideline/5.6.0.SP1.RELEASE/ja/ArchitectureInDetail/WebApplicationDetail/SessionManagement.html
@@ -22,7 +22,13 @@
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />
     <link rel="next" title="4.4. ページネーション" href="Pagination.html" />
-    <link rel="prev" title="4.2. 例外ハンドリング" href="ExceptionHandling.html" /><script src="../../_static/jquery.treeview.js" type="text/javascript"></script>
+    <link rel="prev" title="4.2. 例外ハンドリング" href="ExceptionHandling.html" /><script async src="https://www.googletagmanager.com/gtag/js?id=G-847V2Q99G8"></script>
+<script>
+window.dataLayer = window.dataLayer || [];
+function gtag(){dataLayer.push(arguments);}
+gtag('js', new Date()); gtag('config', 'G-847V2Q99G8');
+</script>
+<script src="../../_static/jquery.treeview.js" type="text/javascript"></script>
 <!-- <link href='http://fonts.googleapis.com/css?family=Source+Code+Pro|Open+Sans:300italic,400italic,700italic,400,300,700' rel='stylesheet' type='text/css'> -->
 <link href="../../_static/solarized-dark.css" rel="stylesheet">
 <link href="../../_static/jquery.treeview.css" rel="stylesheet">
@@ -140,10 +146,6 @@
             
   <div class="section" id="id1">
 <h1>4.3. セッション管理<a class="headerlink" href="#id1" title="Permalink to this headline">¶</a></h1>
-<div class="admonition caution">
-  <p class="first admonition-title">Caution</p>
-  <p><strong>本バージョンの内容は既に古くなっています</strong>。最新のガイドラインは<a href="http://terasolunaorg.github.io/guideline/">こちら</a>からご参照ください。</p>
-</div>
 <div class="contents local topic" id="id2">
 <p class="topic-title">目次</p>
 <ul class="simple">

--- a/guideline/5.6.0.SP1.RELEASE/ja/ArchitectureInDetail/WebApplicationDetail/TagLibAndELFunctions.html
+++ b/guideline/5.6.0.SP1.RELEASE/ja/ArchitectureInDetail/WebApplicationDetail/TagLibAndELFunctions.html
@@ -22,7 +22,13 @@
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />
     <link rel="next" title="4.13. Ajax" href="Ajax.html" />
-    <link rel="prev" title="4.11. Tilesによる画面レイアウト" href="TilesLayout.html" /><script src="../../_static/jquery.treeview.js" type="text/javascript"></script>
+    <link rel="prev" title="4.11. Tilesによる画面レイアウト" href="TilesLayout.html" /><script async src="https://www.googletagmanager.com/gtag/js?id=G-847V2Q99G8"></script>
+<script>
+window.dataLayer = window.dataLayer || [];
+function gtag(){dataLayer.push(arguments);}
+gtag('js', new Date()); gtag('config', 'G-847V2Q99G8');
+</script>
+<script src="../../_static/jquery.treeview.js" type="text/javascript"></script>
 <!-- <link href='http://fonts.googleapis.com/css?family=Source+Code+Pro|Open+Sans:300italic,400italic,700italic,400,300,700' rel='stylesheet' type='text/css'> -->
 <link href="../../_static/solarized-dark.css" rel="stylesheet">
 <link href="../../_static/jquery.treeview.css" rel="stylesheet">
@@ -139,10 +145,6 @@
             
   <div class="section" id="jsp-tag-library-el-functions">
 <h1>4.12. 共通ライブラリが提供するJSP Tag Library と EL Functions<a class="headerlink" href="#jsp-tag-library-el-functions" title="Permalink to this headline">¶</a></h1>
-<div class="admonition caution">
-  <p class="first admonition-title">Caution</p>
-  <p><strong>本バージョンの内容は既に古くなっています</strong>。最新のガイドラインは<a href="http://terasolunaorg.github.io/guideline/">こちら</a>からご参照ください。</p>
-</div>
 <div class="contents local topic" id="id1">
 <p class="topic-title">目次</p>
 <ul class="simple">

--- a/guideline/5.6.0.SP1.RELEASE/ja/ArchitectureInDetail/WebApplicationDetail/TilesLayout.html
+++ b/guideline/5.6.0.SP1.RELEASE/ja/ArchitectureInDetail/WebApplicationDetail/TilesLayout.html
@@ -22,7 +22,13 @@
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />
     <link rel="next" title="4.12. 共通ライブラリが提供するJSP Tag Library と EL Functions" href="TagLibAndELFunctions.html" />
-    <link rel="prev" title="4.10. ファイルダウンロード" href="FileDownload.html" /><script src="../../_static/jquery.treeview.js" type="text/javascript"></script>
+    <link rel="prev" title="4.10. ファイルダウンロード" href="FileDownload.html" /><script async src="https://www.googletagmanager.com/gtag/js?id=G-847V2Q99G8"></script>
+<script>
+window.dataLayer = window.dataLayer || [];
+function gtag(){dataLayer.push(arguments);}
+gtag('js', new Date()); gtag('config', 'G-847V2Q99G8');
+</script>
+<script src="../../_static/jquery.treeview.js" type="text/javascript"></script>
 <!-- <link href='http://fonts.googleapis.com/css?family=Source+Code+Pro|Open+Sans:300italic,400italic,700italic,400,300,700' rel='stylesheet' type='text/css'> -->
 <link href="../../_static/solarized-dark.css" rel="stylesheet">
 <link href="../../_static/jquery.treeview.css" rel="stylesheet">
@@ -98,10 +104,6 @@
             
   <div class="section" id="tiles">
 <h1>4.11. Tilesによる画面レイアウト<a class="headerlink" href="#tiles" title="Permalink to this headline">¶</a></h1>
-<div class="admonition caution">
-  <p class="first admonition-title">Caution</p>
-  <p><strong>本バージョンの内容は既に古くなっています</strong>。最新のガイドラインは<a href="http://terasolunaorg.github.io/guideline/">こちら</a>からご参照ください。</p>
-</div>
 <div class="contents local topic" id="id1">
 <p class="topic-title">目次</p>
 <ul class="simple">

--- a/guideline/5.6.0.SP1.RELEASE/ja/ArchitectureInDetail/WebApplicationDetail/Validation.html
+++ b/guideline/5.6.0.SP1.RELEASE/ja/ArchitectureInDetail/WebApplicationDetail/Validation.html
@@ -22,7 +22,13 @@
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />
     <link rel="next" title="4.2. 例外ハンドリング" href="ExceptionHandling.html" />
-    <link rel="prev" title="4. Webアプリ開発機能" href="index.html" /><script src="../../_static/jquery.treeview.js" type="text/javascript"></script>
+    <link rel="prev" title="4. Webアプリ開発機能" href="index.html" /><script async src="https://www.googletagmanager.com/gtag/js?id=G-847V2Q99G8"></script>
+<script>
+window.dataLayer = window.dataLayer || [];
+function gtag(){dataLayer.push(arguments);}
+gtag('js', new Date()); gtag('config', 'G-847V2Q99G8');
+</script>
+<script src="../../_static/jquery.treeview.js" type="text/javascript"></script>
 <!-- <link href='http://fonts.googleapis.com/css?family=Source+Code+Pro|Open+Sans:300italic,400italic,700italic,400,300,700' rel='stylesheet' type='text/css'> -->
 <link href="../../_static/solarized-dark.css" rel="stylesheet">
 <link href="../../_static/jquery.treeview.css" rel="stylesheet">
@@ -156,10 +162,6 @@
             
   <div class="section" id="id1">
 <h1><a class="toc-backref" href="#id42">4.1. 入力チェック</a><a class="headerlink" href="#id1" title="Permalink to this headline">¶</a></h1>
-<div class="admonition caution">
-  <p class="first admonition-title">Caution</p>
-  <p><strong>本バージョンの内容は既に古くなっています</strong>。最新のガイドラインは<a href="http://terasolunaorg.github.io/guideline/">こちら</a>からご参照ください。</p>
-</div>
 <div class="contents topic" id="id2">
 <p class="topic-title">目次</p>
 <ul class="simple">

--- a/guideline/5.6.0.SP1.RELEASE/ja/ArchitectureInDetail/WebApplicationDetail/index.html
+++ b/guideline/5.6.0.SP1.RELEASE/ja/ArchitectureInDetail/WebApplicationDetail/index.html
@@ -22,7 +22,13 @@
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />
     <link rel="next" title="4.1. 入力チェック" href="Validation.html" />
-    <link rel="prev" title="3.5. 開発プロジェクトのビルド" href="../../ImplementationAtEachLayer/CreateProject.html" /><script src="../../_static/jquery.treeview.js" type="text/javascript"></script>
+    <link rel="prev" title="3.5. 開発プロジェクトのビルド" href="../../ImplementationAtEachLayer/CreateProject.html" /><script async src="https://www.googletagmanager.com/gtag/js?id=G-847V2Q99G8"></script>
+<script>
+window.dataLayer = window.dataLayer || [];
+function gtag(){dataLayer.push(arguments);}
+gtag('js', new Date()); gtag('config', 'G-847V2Q99G8');
+</script>
+<script src="../../_static/jquery.treeview.js" type="text/javascript"></script>
 <!-- <link href='http://fonts.googleapis.com/css?family=Source+Code+Pro|Open+Sans:300italic,400italic,700italic,400,300,700' rel='stylesheet' type='text/css'> -->
 <link href="../../_static/solarized-dark.css" rel="stylesheet">
 <link href="../../_static/jquery.treeview.css" rel="stylesheet">
@@ -80,10 +86,6 @@
             
   <div class="section" id="web">
 <h1>4. Webアプリ開発機能<a class="headerlink" href="#web" title="Permalink to this headline">¶</a></h1>
-<div class="admonition caution">
-  <p class="first admonition-title">Caution</p>
-  <p><strong>本バージョンの内容は既に古くなっています</strong>。最新のガイドラインは<a href="http://terasolunaorg.github.io/guideline/">こちら</a>からご参照ください。</p>
-</div>
 <p>本ガイドラインで想定しているWeb機能詳細アーキテクチャについて説明する。</p>
 <div class="toctree-wrapper compound">
 <ul>

--- a/guideline/5.6.0.SP1.RELEASE/ja/ArchitectureInDetail/WebServiceDetail/REST.html
+++ b/guideline/5.6.0.SP1.RELEASE/ja/ArchitectureInDetail/WebServiceDetail/REST.html
@@ -22,7 +22,13 @@
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />
     <link rel="next" title="5.2. RESTクライアント（HTTPクライアント）" href="RestClient.html" />
-    <link rel="prev" title="5. Web Service" href="index.html" /><script src="../../_static/jquery.treeview.js" type="text/javascript"></script>
+    <link rel="prev" title="5. Web Service" href="index.html" /><script async src="https://www.googletagmanager.com/gtag/js?id=G-847V2Q99G8"></script>
+<script>
+window.dataLayer = window.dataLayer || [];
+function gtag(){dataLayer.push(arguments);}
+gtag('js', new Date()); gtag('config', 'G-847V2Q99G8');
+</script>
+<script src="../../_static/jquery.treeview.js" type="text/javascript"></script>
 <!-- <link href='http://fonts.googleapis.com/css?family=Source+Code+Pro|Open+Sans:300italic,400italic,700italic,400,300,700' rel='stylesheet' type='text/css'> -->
 <link href="../../_static/solarized-dark.css" rel="stylesheet">
 <link href="../../_static/jquery.treeview.css" rel="stylesheet">
@@ -228,10 +234,6 @@
             
   <div class="section" id="restful-web-service">
 <h1>5.1. RESTful Web Service<a class="headerlink" href="#restful-web-service" title="Permalink to this headline">¶</a></h1>
-<div class="admonition caution">
-  <p class="first admonition-title">Caution</p>
-  <p><strong>本バージョンの内容は既に古くなっています</strong>。最新のガイドラインは<a href="http://terasolunaorg.github.io/guideline/">こちら</a>からご参照ください。</p>
-</div>
 <div class="contents local topic" id="id1">
 <p class="topic-title">目次</p>
 <ul class="simple">

--- a/guideline/5.6.0.SP1.RELEASE/ja/ArchitectureInDetail/WebServiceDetail/RestClient.html
+++ b/guideline/5.6.0.SP1.RELEASE/ja/ArchitectureInDetail/WebServiceDetail/RestClient.html
@@ -22,7 +22,13 @@
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />
     <link rel="next" title="5.3. SOAP Web Service（サーバ/クライアント）" href="SOAP.html" />
-    <link rel="prev" title="5.1. RESTful Web Service" href="REST.html" /><script src="../../_static/jquery.treeview.js" type="text/javascript"></script>
+    <link rel="prev" title="5.1. RESTful Web Service" href="REST.html" /><script async src="https://www.googletagmanager.com/gtag/js?id=G-847V2Q99G8"></script>
+<script>
+window.dataLayer = window.dataLayer || [];
+function gtag(){dataLayer.push(arguments);}
+gtag('js', new Date()); gtag('config', 'G-847V2Q99G8');
+</script>
+<script src="../../_static/jquery.treeview.js" type="text/javascript"></script>
 <!-- <link href='http://fonts.googleapis.com/css?family=Source+Code+Pro|Open+Sans:300italic,400italic,700italic,400,300,700' rel='stylesheet' type='text/css'> -->
 <link href="../../_static/solarized-dark.css" rel="stylesheet">
 <link href="../../_static/jquery.treeview.css" rel="stylesheet">
@@ -166,10 +172,6 @@
             
   <div class="section" id="rest-http">
 <h1>5.2. RESTクライアント（HTTPクライアント）<a class="headerlink" href="#rest-http" title="Permalink to this headline">¶</a></h1>
-<div class="admonition caution">
-  <p class="first admonition-title">Caution</p>
-  <p><strong>本バージョンの内容は既に古くなっています</strong>。最新のガイドラインは<a href="http://terasolunaorg.github.io/guideline/">こちら</a>からご参照ください。</p>
-</div>
 <div class="contents local topic" id="id1">
 <p class="topic-title">目次</p>
 <ul class="simple">

--- a/guideline/5.6.0.SP1.RELEASE/ja/ArchitectureInDetail/WebServiceDetail/SOAP.html
+++ b/guideline/5.6.0.SP1.RELEASE/ja/ArchitectureInDetail/WebServiceDetail/SOAP.html
@@ -22,7 +22,13 @@
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />
     <link rel="next" title="6. データアクセス" href="../DataAccessDetail/index.html" />
-    <link rel="prev" title="5.2. RESTクライアント（HTTPクライアント）" href="RestClient.html" /><script src="../../_static/jquery.treeview.js" type="text/javascript"></script>
+    <link rel="prev" title="5.2. RESTクライアント（HTTPクライアント）" href="RestClient.html" /><script async src="https://www.googletagmanager.com/gtag/js?id=G-847V2Q99G8"></script>
+<script>
+window.dataLayer = window.dataLayer || [];
+function gtag(){dataLayer.push(arguments);}
+gtag('js', new Date()); gtag('config', 'G-847V2Q99G8');
+</script>
+<script src="../../_static/jquery.treeview.js" type="text/javascript"></script>
 <!-- <link href='http://fonts.googleapis.com/css?family=Source+Code+Pro|Open+Sans:300italic,400italic,700italic,400,300,700' rel='stylesheet' type='text/css'> -->
 <link href="../../_static/solarized-dark.css" rel="stylesheet">
 <link href="../../_static/jquery.treeview.css" rel="stylesheet">
@@ -154,10 +160,6 @@
             
   <div class="section" id="soap-web-service">
 <h1>5.3. SOAP Web Service（サーバ/クライアント）<a class="headerlink" href="#soap-web-service" title="Permalink to this headline">¶</a></h1>
-<div class="admonition caution">
-  <p class="first admonition-title">Caution</p>
-  <p><strong>本バージョンの内容は既に古くなっています</strong>。最新のガイドラインは<a href="http://terasolunaorg.github.io/guideline/">こちら</a>からご参照ください。</p>
-</div>
 <div class="contents local topic" id="id1">
 <p class="topic-title">目次</p>
 <ul class="simple">

--- a/guideline/5.6.0.SP1.RELEASE/ja/ArchitectureInDetail/WebServiceDetail/index.html
+++ b/guideline/5.6.0.SP1.RELEASE/ja/ArchitectureInDetail/WebServiceDetail/index.html
@@ -22,7 +22,13 @@
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />
     <link rel="next" title="5.1. RESTful Web Service" href="REST.html" />
-    <link rel="prev" title="4.14. ヘルスチェック" href="../WebApplicationDetail/HealthCheck.html" /><script src="../../_static/jquery.treeview.js" type="text/javascript"></script>
+    <link rel="prev" title="4.14. ヘルスチェック" href="../WebApplicationDetail/HealthCheck.html" /><script async src="https://www.googletagmanager.com/gtag/js?id=G-847V2Q99G8"></script>
+<script>
+window.dataLayer = window.dataLayer || [];
+function gtag(){dataLayer.push(arguments);}
+gtag('js', new Date()); gtag('config', 'G-847V2Q99G8');
+</script>
+<script src="../../_static/jquery.treeview.js" type="text/javascript"></script>
 <!-- <link href='http://fonts.googleapis.com/css?family=Source+Code+Pro|Open+Sans:300italic,400italic,700italic,400,300,700' rel='stylesheet' type='text/css'> -->
 <link href="../../_static/solarized-dark.css" rel="stylesheet">
 <link href="../../_static/jquery.treeview.css" rel="stylesheet">
@@ -80,10 +86,6 @@
             
   <div class="section" id="web-service">
 <h1>5. Web Service<a class="headerlink" href="#web-service" title="Permalink to this headline">¶</a></h1>
-<div class="admonition caution">
-  <p class="first admonition-title">Caution</p>
-  <p><strong>本バージョンの内容は既に古くなっています</strong>。最新のガイドラインは<a href="http://terasolunaorg.github.io/guideline/">こちら</a>からご参照ください。</p>
-</div>
 <p>本ガイドラインで想定しているWebサービスアーキテクチャについて説明する。</p>
 <div class="toctree-wrapper compound">
 <ul>

--- a/guideline/5.6.0.SP1.RELEASE/ja/ArchitectureInDetail/index.html
+++ b/guideline/5.6.0.SP1.RELEASE/ja/ArchitectureInDetail/index.html
@@ -20,7 +20,13 @@
     <script type="text/javascript" src="../_static/underscore.js"></script>
     <script type="text/javascript" src="../_static/doctools.js"></script>
     <link rel="index" title="Index" href="../genindex.html" />
-    <link rel="search" title="Search" href="../search.html" /><script src="../_static/jquery.treeview.js" type="text/javascript"></script>
+    <link rel="search" title="Search" href="../search.html" /><script async src="https://www.googletagmanager.com/gtag/js?id=G-847V2Q99G8"></script>
+<script>
+window.dataLayer = window.dataLayer || [];
+function gtag(){dataLayer.push(arguments);}
+gtag('js', new Date()); gtag('config', 'G-847V2Q99G8');
+</script>
+<script src="../_static/jquery.treeview.js" type="text/javascript"></script>
 <!-- <link href='http://fonts.googleapis.com/css?family=Source+Code+Pro|Open+Sans:300italic,400italic,700italic,400,300,700' rel='stylesheet' type='text/css'> -->
 <link href="../_static/solarized-dark.css" rel="stylesheet">
 <link href="../_static/jquery.treeview.css" rel="stylesheet">
@@ -66,10 +72,6 @@
             
   <div class="section" id="id1">
 <h1>機能詳細<a class="headerlink" href="#id1" title="Permalink to this headline">¶</a></h1>
-<div class="admonition caution">
-  <p class="first admonition-title">Caution</p>
-  <p><strong>本バージョンの内容は既に古くなっています</strong>。最新のガイドラインは<a href="http://terasolunaorg.github.io/guideline/">こちら</a>からご参照ください。</p>
-</div>
 <p>本ガイドラインで想定しているアーキテクチャについて説明する。</p>
 <div class="toctree-wrapper compound">
 <ul>

--- a/guideline/5.6.0.SP1.RELEASE/ja/ImplementationAtEachLayer/ApplicationLayer.html
+++ b/guideline/5.6.0.SP1.RELEASE/ja/ImplementationAtEachLayer/ApplicationLayer.html
@@ -22,7 +22,13 @@
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />
     <link rel="next" title="3.5. 開発プロジェクトのビルド" href="CreateProject.html" />
-    <link rel="prev" title="3.3. インフラストラクチャ層の実装" href="InfrastructureLayer.html" /><script src="../_static/jquery.treeview.js" type="text/javascript"></script>
+    <link rel="prev" title="3.3. インフラストラクチャ層の実装" href="InfrastructureLayer.html" /><script async src="https://www.googletagmanager.com/gtag/js?id=G-847V2Q99G8"></script>
+<script>
+window.dataLayer = window.dataLayer || [];
+function gtag(){dataLayer.push(arguments);}
+gtag('js', new Date()); gtag('config', 'G-847V2Q99G8');
+</script>
+<script src="../_static/jquery.treeview.js" type="text/javascript"></script>
 <!-- <link href='http://fonts.googleapis.com/css?family=Source+Code+Pro|Open+Sans:300italic,400italic,700italic,400,300,700' rel='stylesheet' type='text/css'> -->
 <link href="../_static/solarized-dark.css" rel="stylesheet">
 <link href="../_static/jquery.treeview.css" rel="stylesheet">
@@ -195,10 +201,6 @@
             
   <div class="section" id="id1">
 <h1>3.4. アプリケーション層の実装<a class="headerlink" href="#id1" title="Permalink to this headline">¶</a></h1>
-<div class="admonition caution">
-  <p class="first admonition-title">Caution</p>
-  <p><strong>本バージョンの内容は既に古くなっています</strong>。最新のガイドラインは<a href="http://terasolunaorg.github.io/guideline/">こちら</a>からご参照ください。</p>
-</div>
 <div class="contents local topic" id="id2">
 <p class="topic-title">目次</p>
 <ul class="simple">

--- a/guideline/5.6.0.SP1.RELEASE/ja/ImplementationAtEachLayer/CreateProject.html
+++ b/guideline/5.6.0.SP1.RELEASE/ja/ImplementationAtEachLayer/CreateProject.html
@@ -22,7 +22,13 @@
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />
     <link rel="next" title="4. Webアプリ開発機能" href="../ArchitectureInDetail/WebApplicationDetail/index.html" />
-    <link rel="prev" title="3.4. アプリケーション層の実装" href="ApplicationLayer.html" /><script src="../_static/jquery.treeview.js" type="text/javascript"></script>
+    <link rel="prev" title="3.4. アプリケーション層の実装" href="ApplicationLayer.html" /><script async src="https://www.googletagmanager.com/gtag/js?id=G-847V2Q99G8"></script>
+<script>
+window.dataLayer = window.dataLayer || [];
+function gtag(){dataLayer.push(arguments);}
+gtag('js', new Date()); gtag('config', 'G-847V2Q99G8');
+</script>
+<script src="../_static/jquery.treeview.js" type="text/javascript"></script>
 <!-- <link href='http://fonts.googleapis.com/css?family=Source+Code+Pro|Open+Sans:300italic,400italic,700italic,400,300,700' rel='stylesheet' type='text/css'> -->
 <link href="../_static/solarized-dark.css" rel="stylesheet">
 <link href="../_static/jquery.treeview.css" rel="stylesheet">
@@ -111,10 +117,6 @@
             
   <div class="section" id="id1">
 <h1>3.5. 開発プロジェクトのビルド<a class="headerlink" href="#id1" title="Permalink to this headline">¶</a></h1>
-<div class="admonition caution">
-  <p class="first admonition-title">Caution</p>
-  <p><strong>本バージョンの内容は既に古くなっています</strong>。最新のガイドラインは<a href="http://terasolunaorg.github.io/guideline/">こちら</a>からご参照ください。</p>
-</div>
 <div class="contents local topic" id="id2">
 <p class="topic-title">目次</p>
 <ul class="simple">

--- a/guideline/5.6.0.SP1.RELEASE/ja/ImplementationAtEachLayer/CreateWebApplicationProject.html
+++ b/guideline/5.6.0.SP1.RELEASE/ja/ImplementationAtEachLayer/CreateWebApplicationProject.html
@@ -22,7 +22,13 @@
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />
     <link rel="next" title="3.2. ドメイン層の実装" href="DomainLayer.html" />
-    <link rel="prev" title="3. アプリケーション開発" href="index.html" /><script src="../_static/jquery.treeview.js" type="text/javascript"></script>
+    <link rel="prev" title="3. アプリケーション開発" href="index.html" /><script async src="https://www.googletagmanager.com/gtag/js?id=G-847V2Q99G8"></script>
+<script>
+window.dataLayer = window.dataLayer || [];
+function gtag(){dataLayer.push(arguments);}
+gtag('js', new Date()); gtag('config', 'G-847V2Q99G8');
+</script>
+<script src="../_static/jquery.treeview.js" type="text/javascript"></script>
 <!-- <link href='http://fonts.googleapis.com/css?family=Source+Code+Pro|Open+Sans:300italic,400italic,700italic,400,300,700' rel='stylesheet' type='text/css'> -->
 <link href="../_static/solarized-dark.css" rel="stylesheet">
 <link href="../_static/jquery.treeview.css" rel="stylesheet">
@@ -115,10 +121,6 @@
             
   <div class="section" id="web">
 <h1>3.1. Webアプリケーション向け開発プロジェクトの作成<a class="headerlink" href="#web" title="Permalink to this headline">¶</a></h1>
-<div class="admonition caution">
-  <p class="first admonition-title">Caution</p>
-  <p><strong>本バージョンの内容は既に古くなっています</strong>。最新のガイドラインは<a href="http://terasolunaorg.github.io/guideline/">こちら</a>からご参照ください。</p>
-</div>
 <div class="contents local topic" id="id1">
 <p class="topic-title">目次</p>
 <ul class="simple">

--- a/guideline/5.6.0.SP1.RELEASE/ja/ImplementationAtEachLayer/DomainLayer.html
+++ b/guideline/5.6.0.SP1.RELEASE/ja/ImplementationAtEachLayer/DomainLayer.html
@@ -22,7 +22,13 @@
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />
     <link rel="next" title="3.3. インフラストラクチャ層の実装" href="InfrastructureLayer.html" />
-    <link rel="prev" title="3.1. Webアプリケーション向け開発プロジェクトの作成" href="CreateWebApplicationProject.html" /><script src="../_static/jquery.treeview.js" type="text/javascript"></script>
+    <link rel="prev" title="3.1. Webアプリケーション向け開発プロジェクトの作成" href="CreateWebApplicationProject.html" /><script async src="https://www.googletagmanager.com/gtag/js?id=G-847V2Q99G8"></script>
+<script>
+window.dataLayer = window.dataLayer || [];
+function gtag(){dataLayer.push(arguments);}
+gtag('js', new Date()); gtag('config', 'G-847V2Q99G8');
+</script>
+<script src="../_static/jquery.treeview.js" type="text/javascript"></script>
 <!-- <link href='http://fonts.googleapis.com/css?family=Source+Code+Pro|Open+Sans:300italic,400italic,700italic,400,300,700' rel='stylesheet' type='text/css'> -->
 <link href="../_static/solarized-dark.css" rel="stylesheet">
 <link href="../_static/jquery.treeview.css" rel="stylesheet">
@@ -171,10 +177,6 @@
             
   <div class="section" id="id1">
 <h1>3.2. ドメイン層の実装<a class="headerlink" href="#id1" title="Permalink to this headline">¶</a></h1>
-<div class="admonition caution">
-  <p class="first admonition-title">Caution</p>
-  <p><strong>本バージョンの内容は既に古くなっています</strong>。最新のガイドラインは<a href="http://terasolunaorg.github.io/guideline/">こちら</a>からご参照ください。</p>
-</div>
 <div class="contents local topic" id="id2">
 <p class="topic-title">目次</p>
 <ul class="simple">

--- a/guideline/5.6.0.SP1.RELEASE/ja/ImplementationAtEachLayer/InfrastructureLayer.html
+++ b/guideline/5.6.0.SP1.RELEASE/ja/ImplementationAtEachLayer/InfrastructureLayer.html
@@ -22,7 +22,13 @@
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />
     <link rel="next" title="3.4. アプリケーション層の実装" href="ApplicationLayer.html" />
-    <link rel="prev" title="3.2. ドメイン層の実装" href="DomainLayer.html" /><script src="../_static/jquery.treeview.js" type="text/javascript"></script>
+    <link rel="prev" title="3.2. ドメイン層の実装" href="DomainLayer.html" /><script async src="https://www.googletagmanager.com/gtag/js?id=G-847V2Q99G8"></script>
+<script>
+window.dataLayer = window.dataLayer || [];
+function gtag(){dataLayer.push(arguments);}
+gtag('js', new Date()); gtag('config', 'G-847V2Q99G8');
+</script>
+<script src="../_static/jquery.treeview.js" type="text/javascript"></script>
 <!-- <link href='http://fonts.googleapis.com/css?family=Source+Code+Pro|Open+Sans:300italic,400italic,700italic,400,300,700' rel='stylesheet' type='text/css'> -->
 <link href="../_static/solarized-dark.css" rel="stylesheet">
 <link href="../_static/jquery.treeview.css" rel="stylesheet">
@@ -93,10 +99,6 @@
             
   <div class="section" id="id1">
 <h1>3.3. インフラストラクチャ層の実装<a class="headerlink" href="#id1" title="Permalink to this headline">¶</a></h1>
-<div class="admonition caution">
-  <p class="first admonition-title">Caution</p>
-  <p><strong>本バージョンの内容は既に古くなっています</strong>。最新のガイドラインは<a href="http://terasolunaorg.github.io/guideline/">こちら</a>からご参照ください。</p>
-</div>
 <div class="contents local topic" id="id2">
 <p class="topic-title">目次</p>
 <ul class="simple">

--- a/guideline/5.6.0.SP1.RELEASE/ja/ImplementationAtEachLayer/index.html
+++ b/guideline/5.6.0.SP1.RELEASE/ja/ImplementationAtEachLayer/index.html
@@ -22,7 +22,13 @@
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />
     <link rel="next" title="3.1. Webアプリケーション向け開発プロジェクトの作成" href="CreateWebApplicationProject.html" />
-    <link rel="prev" title="2.4. アプリケーションのレイヤ化" href="../Overview/ApplicationLayering.html" /><script src="../_static/jquery.treeview.js" type="text/javascript"></script>
+    <link rel="prev" title="2.4. アプリケーションのレイヤ化" href="../Overview/ApplicationLayering.html" /><script async src="https://www.googletagmanager.com/gtag/js?id=G-847V2Q99G8"></script>
+<script>
+window.dataLayer = window.dataLayer || [];
+function gtag(){dataLayer.push(arguments);}
+gtag('js', new Date()); gtag('config', 'G-847V2Q99G8');
+</script>
+<script src="../_static/jquery.treeview.js" type="text/javascript"></script>
 <!-- <link href='http://fonts.googleapis.com/css?family=Source+Code+Pro|Open+Sans:300italic,400italic,700italic,400,300,700' rel='stylesheet' type='text/css'> -->
 <link href="../_static/solarized-dark.css" rel="stylesheet">
 <link href="../_static/jquery.treeview.css" rel="stylesheet">
@@ -80,10 +86,6 @@
             
   <div class="section" id="id1">
 <h1>3. アプリケーション開発<a class="headerlink" href="#id1" title="Permalink to this headline">¶</a></h1>
-<div class="admonition caution">
-  <p class="first admonition-title">Caution</p>
-  <p><strong>本バージョンの内容は既に古くなっています</strong>。最新のガイドラインは<a href="http://terasolunaorg.github.io/guideline/">こちら</a>からご参照ください。</p>
-</div>
 <p>TERASOLUNA Server Framework for Java (5.x)を使用する上での各種ルールや推奨実装方法を記述する。</p>
 <p>本ガイドラインでは以下のような開発の流れを想定している。</p>
 <div class="toctree-wrapper compound">

--- a/guideline/5.6.0.SP1.RELEASE/ja/Introduction/ChangeLog.html
+++ b/guideline/5.6.0.SP1.RELEASE/ja/Introduction/ChangeLog.html
@@ -22,7 +22,13 @@
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />
     <link rel="next" title="2. アーキテクチャ概要" href="../Overview/index.html" />
-    <link rel="prev" title="1.8. ガイドラインの観点別マッピング" href="CriteriaBasedMapping.html" /><script src="../_static/jquery.treeview.js" type="text/javascript"></script>
+    <link rel="prev" title="1.8. ガイドラインの観点別マッピング" href="CriteriaBasedMapping.html" /><script async src="https://www.googletagmanager.com/gtag/js?id=G-847V2Q99G8"></script>
+<script>
+window.dataLayer = window.dataLayer || [];
+function gtag(){dataLayer.push(arguments);}
+gtag('js', new Date()); gtag('config', 'G-847V2Q99G8');
+</script>
+<script src="../_static/jquery.treeview.js" type="text/javascript"></script>
 <!-- <link href='http://fonts.googleapis.com/css?family=Source+Code+Pro|Open+Sans:300italic,400italic,700italic,400,300,700' rel='stylesheet' type='text/css'> -->
 <link href="../_static/solarized-dark.css" rel="stylesheet">
 <link href="../_static/jquery.treeview.css" rel="stylesheet">
@@ -81,10 +87,6 @@
             
   <div class="section" id="id1">
 <h1>1.9. 更新履歴<a class="headerlink" href="#id1" title="Permalink to this headline">¶</a></h1>
-<div class="admonition caution">
-  <p class="first admonition-title">Caution</p>
-  <p><strong>本バージョンの内容は既に古くなっています</strong>。最新のガイドラインは<a href="http://terasolunaorg.github.io/guideline/">こちら</a>からご参照ください。</p>
-</div>
 <table border="1" class="colwidths-given longtable docutils">
 <colgroup>
 <col width="15%" />

--- a/guideline/5.6.0.SP1.RELEASE/ja/Introduction/CriteriaBasedMapping.html
+++ b/guideline/5.6.0.SP1.RELEASE/ja/Introduction/CriteriaBasedMapping.html
@@ -22,7 +22,13 @@
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />
     <link rel="next" title="1.9. 更新履歴" href="ChangeLog.html" />
-    <link rel="prev" title="1.3. このドキュメントが示すこと" href="Introduction.html" /><script src="../_static/jquery.treeview.js" type="text/javascript"></script>
+    <link rel="prev" title="1.3. このドキュメントが示すこと" href="Introduction.html" /><script async src="https://www.googletagmanager.com/gtag/js?id=G-847V2Q99G8"></script>
+<script>
+window.dataLayer = window.dataLayer || [];
+function gtag(){dataLayer.push(arguments);}
+gtag('js', new Date()); gtag('config', 'G-847V2Q99G8');
+</script>
+<script src="../_static/jquery.treeview.js" type="text/javascript"></script>
 <!-- <link href='http://fonts.googleapis.com/css?family=Source+Code+Pro|Open+Sans:300italic,400italic,700italic,400,300,700' rel='stylesheet' type='text/css'> -->
 <link href="../_static/solarized-dark.css" rel="stylesheet">
 <link href="../_static/jquery.treeview.css" rel="stylesheet">
@@ -93,10 +99,6 @@
             
   <div class="section" id="id1">
 <h1>1.8. ガイドラインの観点別マッピング<a class="headerlink" href="#id1" title="Permalink to this headline">¶</a></h1>
-<div class="admonition caution">
-  <p class="first admonition-title">Caution</p>
-  <p><strong>本バージョンの内容は既に古くなっています</strong>。最新のガイドラインは<a href="http://terasolunaorg.github.io/guideline/">こちら</a>からご参照ください。</p>
-</div>
 <p>ガイドラインの4章以降は機能別に説明されているが、機能面とは別の観点で、どの節にどの内容が含まれているかのマッピングを示す。</p>
 <div class="section" id="id2">
 <h2>1.8.1. セキュリティ対策に関するマッピング<a class="headerlink" href="#id2" title="Permalink to this headline">¶</a></h2>

--- a/guideline/5.6.0.SP1.RELEASE/ja/Introduction/Introduction.html
+++ b/guideline/5.6.0.SP1.RELEASE/ja/Introduction/Introduction.html
@@ -22,7 +22,13 @@
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />
     <link rel="next" title="1.8. ガイドラインの観点別マッピング" href="CriteriaBasedMapping.html" />
-    <link rel="prev" title="1.1. 利用規約" href="TermsOfUse.html" /><script src="../_static/jquery.treeview.js" type="text/javascript"></script>
+    <link rel="prev" title="1.1. 利用規約" href="TermsOfUse.html" /><script async src="https://www.googletagmanager.com/gtag/js?id=G-847V2Q99G8"></script>
+<script>
+window.dataLayer = window.dataLayer || [];
+function gtag(){dataLayer.push(arguments);}
+gtag('js', new Date()); gtag('config', 'G-847V2Q99G8');
+</script>
+<script src="../_static/jquery.treeview.js" type="text/javascript"></script>
 <!-- <link href='http://fonts.googleapis.com/css?family=Source+Code+Pro|Open+Sans:300italic,400italic,700italic,400,300,700' rel='stylesheet' type='text/css'> -->
 <link href="../_static/solarized-dark.css" rel="stylesheet">
 <link href="../_static/jquery.treeview.css" rel="stylesheet">
@@ -90,10 +96,6 @@
             
   <div class="section" id="id1">
 <h1>1.3. このドキュメントが示すこと<a class="headerlink" href="#id1" title="Permalink to this headline">¶</a></h1>
-<div class="admonition caution">
-  <p class="first admonition-title">Caution</p>
-  <p><strong>本バージョンの内容は既に古くなっています</strong>。最新のガイドラインは<a href="http://terasolunaorg.github.io/guideline/">こちら</a>からご参照ください。</p>
-</div>
 <p>本ガイドラインではSpring、Spring MVCやJPA、MyBatisを中心としたフルスタックフレームワークを利用して、
 保守性の高いWebアプリケーション開発をするためのベストプラクティスを提供する。</p>
 <p>本ガイドラインを読むことで、ソフトウェア開発(主にコーディング)が円滑に進むことを期待する。</p>

--- a/guideline/5.6.0.SP1.RELEASE/ja/Introduction/TermsOfUse.html
+++ b/guideline/5.6.0.SP1.RELEASE/ja/Introduction/TermsOfUse.html
@@ -22,7 +22,13 @@
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />
     <link rel="next" title="1.3. このドキュメントが示すこと" href="Introduction.html" />
-    <link rel="prev" title="1. はじめに" href="index.html" /><script src="../_static/jquery.treeview.js" type="text/javascript"></script>
+    <link rel="prev" title="1. はじめに" href="index.html" /><script async src="https://www.googletagmanager.com/gtag/js?id=G-847V2Q99G8"></script>
+<script>
+window.dataLayer = window.dataLayer || [];
+function gtag(){dataLayer.push(arguments);}
+gtag('js', new Date()); gtag('config', 'G-847V2Q99G8');
+</script>
+<script src="../_static/jquery.treeview.js" type="text/javascript"></script>
 <!-- <link href='http://fonts.googleapis.com/css?family=Source+Code+Pro|Open+Sans:300italic,400italic,700italic,400,300,700' rel='stylesheet' type='text/css'> -->
 <link href="../_static/solarized-dark.css" rel="stylesheet">
 <link href="../_static/jquery.treeview.css" rel="stylesheet">
@@ -90,10 +96,6 @@
             
   <div class="section" id="id1">
 <h1>1.1. 利用規約<a class="headerlink" href="#id1" title="Permalink to this headline">¶</a></h1>
-<div class="admonition caution">
-  <p class="first admonition-title">Caution</p>
-  <p><strong>本バージョンの内容は既に古くなっています</strong>。最新のガイドラインは<a href="http://terasolunaorg.github.io/guideline/">こちら</a>からご参照ください。</p>
-</div>
 <p>本ドキュメントを使用するにあたり、以下の規約に同意していただく必要があります。同意いただけない場合は、本ドキュメント及びその複製物の全てを直ちに消去又は破棄してください。</p>
 <ol class="arabic simple">
 <li>本ドキュメントの著作権及びその他一切の権利は、NTTデータあるいはNTTデータに権利を許諾する第三者に帰属します。</li>

--- a/guideline/5.6.0.SP1.RELEASE/ja/Introduction/index.html
+++ b/guideline/5.6.0.SP1.RELEASE/ja/Introduction/index.html
@@ -22,7 +22,13 @@
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />
     <link rel="next" title="1.1. 利用規約" href="TermsOfUse.html" />
-    <link rel="prev" title="TERASOLUNA Server Framework for Java (5.x) Development Guideline" href="../index.html" /><script src="../_static/jquery.treeview.js" type="text/javascript"></script>
+    <link rel="prev" title="TERASOLUNA Server Framework for Java (5.x) Development Guideline" href="../index.html" /><script async src="https://www.googletagmanager.com/gtag/js?id=G-847V2Q99G8"></script>
+<script>
+window.dataLayer = window.dataLayer || [];
+function gtag(){dataLayer.push(arguments);}
+gtag('js', new Date()); gtag('config', 'G-847V2Q99G8');
+</script>
+<script src="../_static/jquery.treeview.js" type="text/javascript"></script>
 <!-- <link href='http://fonts.googleapis.com/css?family=Source+Code+Pro|Open+Sans:300italic,400italic,700italic,400,300,700' rel='stylesheet' type='text/css'> -->
 <link href="../_static/solarized-dark.css" rel="stylesheet">
 <link href="../_static/jquery.treeview.css" rel="stylesheet">
@@ -80,10 +86,6 @@
             
   <div class="section" id="id1">
 <h1>1. はじめに<a class="headerlink" href="#id1" title="Permalink to this headline">¶</a></h1>
-<div class="admonition caution">
-  <p class="first admonition-title">Caution</p>
-  <p><strong>本バージョンの内容は既に古くなっています</strong>。最新のガイドラインは<a href="http://terasolunaorg.github.io/guideline/">こちら</a>からご参照ください。</p>
-</div>
 <div class="toctree-wrapper compound">
 <ul>
 <li class="toctree-l1"><a class="reference internal" href="TermsOfUse.html">1.1. 利用規約</a></li>

--- a/guideline/5.6.0.SP1.RELEASE/ja/Overview/ApplicationLayering.html
+++ b/guideline/5.6.0.SP1.RELEASE/ja/Overview/ApplicationLayering.html
@@ -22,7 +22,13 @@
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />
     <link rel="next" title="3. アプリケーション開発" href="../ImplementationAtEachLayer/index.html" />
-    <link rel="prev" title="2.3. はじめてのSpring MVCアプリケーション" href="FirstApplication.html" /><script src="../_static/jquery.treeview.js" type="text/javascript"></script>
+    <link rel="prev" title="2.3. はじめてのSpring MVCアプリケーション" href="FirstApplication.html" /><script async src="https://www.googletagmanager.com/gtag/js?id=G-847V2Q99G8"></script>
+<script>
+window.dataLayer = window.dataLayer || [];
+function gtag(){dataLayer.push(arguments);}
+gtag('js', new Date()); gtag('config', 'G-847V2Q99G8');
+</script>
+<script src="../_static/jquery.treeview.js" type="text/javascript"></script>
 <!-- <link href='http://fonts.googleapis.com/css?family=Source+Code+Pro|Open+Sans:300italic,400italic,700italic,400,300,700' rel='stylesheet' type='text/css'> -->
 <link href="../_static/solarized-dark.css" rel="stylesheet">
 <link href="../_static/jquery.treeview.css" rel="stylesheet">
@@ -121,10 +127,6 @@
             
   <div class="section" id="applicationlayering">
 <span id="id1"></span><h1>2.4. アプリケーションのレイヤ化<a class="headerlink" href="#applicationlayering" title="Permalink to this headline">¶</a></h1>
-<div class="admonition caution">
-  <p class="first admonition-title">Caution</p>
-  <p><strong>本バージョンの内容は既に古くなっています</strong>。最新のガイドラインは<a href="http://terasolunaorg.github.io/guideline/">こちら</a>からご参照ください。</p>
-</div>
 <div class="contents local topic" id="id2">
 <p class="topic-title">目次</p>
 <ul class="simple">

--- a/guideline/5.6.0.SP1.RELEASE/ja/Overview/FirstApplication.html
+++ b/guideline/5.6.0.SP1.RELEASE/ja/Overview/FirstApplication.html
@@ -22,7 +22,13 @@
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />
     <link rel="next" title="2.4. アプリケーションのレイヤ化" href="ApplicationLayering.html" />
-    <link rel="prev" title="2.2. Spring MVCアーキテクチャ概要" href="SpringMVCOverview.html" /><script src="../_static/jquery.treeview.js" type="text/javascript"></script>
+    <link rel="prev" title="2.2. Spring MVCアーキテクチャ概要" href="SpringMVCOverview.html" /><script async src="https://www.googletagmanager.com/gtag/js?id=G-847V2Q99G8"></script>
+<script>
+window.dataLayer = window.dataLayer || [];
+function gtag(){dataLayer.push(arguments);}
+gtag('js', new Date()); gtag('config', 'G-847V2Q99G8');
+</script>
+<script src="../_static/jquery.treeview.js" type="text/javascript"></script>
 <!-- <link href='http://fonts.googleapis.com/css?family=Source+Code+Pro|Open+Sans:300italic,400italic,700italic,400,300,700' rel='stylesheet' type='text/css'> -->
 <link href="../_static/solarized-dark.css" rel="stylesheet">
 <link href="../_static/jquery.treeview.css" rel="stylesheet">
@@ -99,10 +105,6 @@
             
   <div class="section" id="spring-mvc">
 <h1>2.3. はじめてのSpring MVCアプリケーション<a class="headerlink" href="#spring-mvc" title="Permalink to this headline">¶</a></h1>
-<div class="admonition caution">
-  <p class="first admonition-title">Caution</p>
-  <p><strong>本バージョンの内容は既に古くなっています</strong>。最新のガイドラインは<a href="http://terasolunaorg.github.io/guideline/">こちら</a>からご参照ください。</p>
-</div>
 <div class="contents local topic" id="id1">
 <p class="topic-title">目次</p>
 <ul class="simple">

--- a/guideline/5.6.0.SP1.RELEASE/ja/Overview/FrameworkStack.html
+++ b/guideline/5.6.0.SP1.RELEASE/ja/Overview/FrameworkStack.html
@@ -22,7 +22,13 @@
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />
     <link rel="next" title="2.2. Spring MVCアーキテクチャ概要" href="SpringMVCOverview.html" />
-    <link rel="prev" title="2. アーキテクチャ概要" href="index.html" /><script src="../_static/jquery.treeview.js" type="text/javascript"></script>
+    <link rel="prev" title="2. アーキテクチャ概要" href="index.html" /><script async src="https://www.googletagmanager.com/gtag/js?id=G-847V2Q99G8"></script>
+<script>
+window.dataLayer = window.dataLayer || [];
+function gtag(){dataLayer.push(arguments);}
+gtag('js', new Date()); gtag('config', 'G-847V2Q99G8');
+</script>
+<script src="../_static/jquery.treeview.js" type="text/javascript"></script>
 <!-- <link href='http://fonts.googleapis.com/css?family=Source+Code+Pro|Open+Sans:300italic,400italic,700italic,400,300,700' rel='stylesheet' type='text/css'> -->
 <link href="../_static/solarized-dark.css" rel="stylesheet">
 <link href="../_static/jquery.treeview.css" rel="stylesheet">
@@ -112,10 +118,6 @@
             
   <div class="section" id="terasoluna-server-framework-for-java-5-x">
 <h1>2.1. TERASOLUNA Server Framework for Java (5.x)のスタック<a class="headerlink" href="#terasoluna-server-framework-for-java-5-x" title="Permalink to this headline">¶</a></h1>
-<div class="admonition caution">
-  <p class="first admonition-title">Caution</p>
-  <p><strong>本バージョンの内容は既に古くなっています</strong>。最新のガイドラインは<a href="http://terasolunaorg.github.io/guideline/">こちら</a>からご参照ください。</p>
-</div>
 <div class="contents local topic" id="id1">
 <p class="topic-title">目次</p>
 <ul class="simple">

--- a/guideline/5.6.0.SP1.RELEASE/ja/Overview/SpringMVCOverview.html
+++ b/guideline/5.6.0.SP1.RELEASE/ja/Overview/SpringMVCOverview.html
@@ -22,7 +22,13 @@
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />
     <link rel="next" title="2.3. はじめてのSpring MVCアプリケーション" href="FirstApplication.html" />
-    <link rel="prev" title="2.1. TERASOLUNA Server Framework for Java (5.x)のスタック" href="FrameworkStack.html" /><script src="../_static/jquery.treeview.js" type="text/javascript"></script>
+    <link rel="prev" title="2.1. TERASOLUNA Server Framework for Java (5.x)のスタック" href="FrameworkStack.html" /><script async src="https://www.googletagmanager.com/gtag/js?id=G-847V2Q99G8"></script>
+<script>
+window.dataLayer = window.dataLayer || [];
+function gtag(){dataLayer.push(arguments);}
+gtag('js', new Date()); gtag('config', 'G-847V2Q99G8');
+</script>
+<script src="../_static/jquery.treeview.js" type="text/javascript"></script>
 <!-- <link href='http://fonts.googleapis.com/css?family=Source+Code+Pro|Open+Sans:300italic,400italic,700italic,400,300,700' rel='stylesheet' type='text/css'> -->
 <link href="../_static/solarized-dark.css" rel="stylesheet">
 <link href="../_static/jquery.treeview.css" rel="stylesheet">
@@ -96,10 +102,6 @@
             
   <div class="section" id="spring-mvc">
 <h1>2.2. Spring MVCアーキテクチャ概要<a class="headerlink" href="#spring-mvc" title="Permalink to this headline">¶</a></h1>
-<div class="admonition caution">
-  <p class="first admonition-title">Caution</p>
-  <p><strong>本バージョンの内容は既に古くなっています</strong>。最新のガイドラインは<a href="http://terasolunaorg.github.io/guideline/">こちら</a>からご参照ください。</p>
-</div>
 <div class="contents local topic" id="id1">
 <p class="topic-title">目次</p>
 <ul class="simple">

--- a/guideline/5.6.0.SP1.RELEASE/ja/Overview/index.html
+++ b/guideline/5.6.0.SP1.RELEASE/ja/Overview/index.html
@@ -22,7 +22,13 @@
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />
     <link rel="next" title="2.1. TERASOLUNA Server Framework for Java (5.x)のスタック" href="FrameworkStack.html" />
-    <link rel="prev" title="1.9. 更新履歴" href="../Introduction/ChangeLog.html" /><script src="../_static/jquery.treeview.js" type="text/javascript"></script>
+    <link rel="prev" title="1.9. 更新履歴" href="../Introduction/ChangeLog.html" /><script async src="https://www.googletagmanager.com/gtag/js?id=G-847V2Q99G8"></script>
+<script>
+window.dataLayer = window.dataLayer || [];
+function gtag(){dataLayer.push(arguments);}
+gtag('js', new Date()); gtag('config', 'G-847V2Q99G8');
+</script>
+<script src="../_static/jquery.treeview.js" type="text/javascript"></script>
 <!-- <link href='http://fonts.googleapis.com/css?family=Source+Code+Pro|Open+Sans:300italic,400italic,700italic,400,300,700' rel='stylesheet' type='text/css'> -->
 <link href="../_static/solarized-dark.css" rel="stylesheet">
 <link href="../_static/jquery.treeview.css" rel="stylesheet">
@@ -80,10 +86,6 @@
             
   <div class="section" id="id1">
 <h1>2. アーキテクチャ概要<a class="headerlink" href="#id1" title="Permalink to this headline">¶</a></h1>
-<div class="admonition caution">
-  <p class="first admonition-title">Caution</p>
-  <p><strong>本バージョンの内容は既に古くなっています</strong>。最新のガイドラインは<a href="http://terasolunaorg.github.io/guideline/">こちら</a>からご参照ください。</p>
-</div>
 <p>本ガイドラインで想定しているアーキテクチャについて説明する。</p>
 <div class="toctree-wrapper compound">
 <ul>

--- a/guideline/5.6.0.SP1.RELEASE/ja/Security/Authentication.html
+++ b/guideline/5.6.0.SP1.RELEASE/ja/Security/Authentication.html
@@ -22,7 +22,13 @@
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />
     <link rel="next" title="9.3. 認可" href="Authorization.html" />
-    <link rel="prev" title="9.1. Spring Security概要" href="SpringSecurity.html" /><script src="../_static/jquery.treeview.js" type="text/javascript"></script>
+    <link rel="prev" title="9.1. Spring Security概要" href="SpringSecurity.html" /><script async src="https://www.googletagmanager.com/gtag/js?id=G-847V2Q99G8"></script>
+<script>
+window.dataLayer = window.dataLayer || [];
+function gtag(){dataLayer.push(arguments);}
+gtag('js', new Date()); gtag('config', 'G-847V2Q99G8');
+</script>
+<script src="../_static/jquery.treeview.js" type="text/javascript"></script>
 <!-- <link href='http://fonts.googleapis.com/css?family=Source+Code+Pro|Open+Sans:300italic,400italic,700italic,400,300,700' rel='stylesheet' type='text/css'> -->
 <link href="../_static/solarized-dark.css" rel="stylesheet">
 <link href="../_static/jquery.treeview.css" rel="stylesheet">
@@ -209,10 +215,6 @@
             
   <div class="section" id="springsecurityauthentication">
 <span id="id1"></span><h1>9.2. 認証<a class="headerlink" href="#springsecurityauthentication" title="Permalink to this headline">¶</a></h1>
-<div class="admonition caution">
-  <p class="first admonition-title">Caution</p>
-  <p><strong>本バージョンの内容は既に古くなっています</strong>。最新のガイドラインは<a href="http://terasolunaorg.github.io/guideline/">こちら</a>からご参照ください。</p>
-</div>
 <div class="contents local topic" id="id2">
 <p class="topic-title">目次</p>
 <ul class="simple">

--- a/guideline/5.6.0.SP1.RELEASE/ja/Security/Authorization.html
+++ b/guideline/5.6.0.SP1.RELEASE/ja/Security/Authorization.html
@@ -22,7 +22,13 @@
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />
     <link rel="next" title="9.4. セッション管理" href="SessionManagement.html" />
-    <link rel="prev" title="9.2. 認証" href="Authentication.html" /><script src="../_static/jquery.treeview.js" type="text/javascript"></script>
+    <link rel="prev" title="9.2. 認証" href="Authentication.html" /><script async src="https://www.googletagmanager.com/gtag/js?id=G-847V2Q99G8"></script>
+<script>
+window.dataLayer = window.dataLayer || [];
+function gtag(){dataLayer.push(arguments);}
+gtag('js', new Date()); gtag('config', 'G-847V2Q99G8');
+</script>
+<script src="../_static/jquery.treeview.js" type="text/javascript"></script>
 <!-- <link href='http://fonts.googleapis.com/css?family=Source+Code+Pro|Open+Sans:300italic,400italic,700italic,400,300,700' rel='stylesheet' type='text/css'> -->
 <link href="../_static/solarized-dark.css" rel="stylesheet">
 <link href="../_static/jquery.treeview.css" rel="stylesheet">
@@ -156,10 +162,6 @@
             
   <div class="section" id="springsecurityauthorization">
 <span id="id1"></span><h1>9.3. 認可<a class="headerlink" href="#springsecurityauthorization" title="Permalink to this headline">¶</a></h1>
-<div class="admonition caution">
-  <p class="first admonition-title">Caution</p>
-  <p><strong>本バージョンの内容は既に古くなっています</strong>。最新のガイドラインは<a href="http://terasolunaorg.github.io/guideline/">こちら</a>からご参照ください。</p>
-</div>
 <div class="contents local topic" id="id2">
 <p class="topic-title">目次</p>
 <ul class="simple">

--- a/guideline/5.6.0.SP1.RELEASE/ja/Security/CSRF.html
+++ b/guideline/5.6.0.SP1.RELEASE/ja/Security/CSRF.html
@@ -22,7 +22,13 @@
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />
     <link rel="next" title="9.6. ブラウザのセキュリティ対策機能との連携" href="LinkageWithBrowser.html" />
-    <link rel="prev" title="9.4. セッション管理" href="SessionManagement.html" /><script src="../_static/jquery.treeview.js" type="text/javascript"></script>
+    <link rel="prev" title="9.4. セッション管理" href="SessionManagement.html" /><script async src="https://www.googletagmanager.com/gtag/js?id=G-847V2Q99G8"></script>
+<script>
+window.dataLayer = window.dataLayer || [];
+function gtag(){dataLayer.push(arguments);}
+gtag('js', new Date()); gtag('config', 'G-847V2Q99G8');
+</script>
+<script src="../_static/jquery.treeview.js" type="text/javascript"></script>
 <!-- <link href='http://fonts.googleapis.com/css?family=Source+Code+Pro|Open+Sans:300italic,400italic,700italic,400,300,700' rel='stylesheet' type='text/css'> -->
 <link href="../_static/solarized-dark.css" rel="stylesheet">
 <link href="../_static/jquery.treeview.css" rel="stylesheet">
@@ -109,10 +115,6 @@
             
   <div class="section" id="csrf">
 <span id="springsecuritycsrf"></span><h1>9.5. CSRF対策<a class="headerlink" href="#csrf" title="Permalink to this headline">¶</a></h1>
-<div class="admonition caution">
-  <p class="first admonition-title">Caution</p>
-  <p><strong>本バージョンの内容は既に古くなっています</strong>。最新のガイドラインは<a href="http://terasolunaorg.github.io/guideline/">こちら</a>からご参照ください。</p>
-</div>
 <div class="contents local topic" id="id1">
 <p class="topic-title">目次</p>
 <ul class="simple">

--- a/guideline/5.6.0.SP1.RELEASE/ja/Security/Encryption.html
+++ b/guideline/5.6.0.SP1.RELEASE/ja/Security/Encryption.html
@@ -22,7 +22,13 @@
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />
     <link rel="next" title="9.9. OAuth" href="OAuth.html" />
-    <link rel="prev" title="9.7. XSS対策" href="XSS.html" /><script src="../_static/jquery.treeview.js" type="text/javascript"></script>
+    <link rel="prev" title="9.7. XSS対策" href="XSS.html" /><script async src="https://www.googletagmanager.com/gtag/js?id=G-847V2Q99G8"></script>
+<script>
+window.dataLayer = window.dataLayer || [];
+function gtag(){dataLayer.push(arguments);}
+gtag('js', new Date()); gtag('config', 'G-847V2Q99G8');
+</script>
+<script src="../_static/jquery.treeview.js" type="text/javascript"></script>
 <!-- <link href='http://fonts.googleapis.com/css?family=Source+Code+Pro|Open+Sans:300italic,400italic,700italic,400,300,700' rel='stylesheet' type='text/css'> -->
 <link href="../_static/solarized-dark.css" rel="stylesheet">
 <link href="../_static/jquery.treeview.css" rel="stylesheet">
@@ -138,10 +144,6 @@
             
   <div class="section" id="id1">
 <h1>9.8. 暗号化<a class="headerlink" href="#id1" title="Permalink to this headline">¶</a></h1>
-<div class="admonition caution">
-  <p class="first admonition-title">Caution</p>
-  <p><strong>本バージョンの内容は既に古くなっています</strong>。最新のガイドラインは<a href="http://terasolunaorg.github.io/guideline/">こちら</a>からご参照ください。</p>
-</div>
 <div class="contents local topic" id="id2">
 <p class="topic-title">目次</p>
 <ul class="simple">

--- a/guideline/5.6.0.SP1.RELEASE/ja/Security/LinkageWithBrowser.html
+++ b/guideline/5.6.0.SP1.RELEASE/ja/Security/LinkageWithBrowser.html
@@ -22,7 +22,13 @@
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />
     <link rel="next" title="9.7. XSS対策" href="XSS.html" />
-    <link rel="prev" title="9.5. CSRF対策" href="CSRF.html" /><script src="../_static/jquery.treeview.js" type="text/javascript"></script>
+    <link rel="prev" title="9.5. CSRF対策" href="CSRF.html" /><script async src="https://www.googletagmanager.com/gtag/js?id=G-847V2Q99G8"></script>
+<script>
+window.dataLayer = window.dataLayer || [];
+function gtag(){dataLayer.push(arguments);}
+gtag('js', new Date()); gtag('config', 'G-847V2Q99G8');
+</script>
+<script src="../_static/jquery.treeview.js" type="text/javascript"></script>
 <!-- <link href='http://fonts.googleapis.com/css?family=Source+Code+Pro|Open+Sans:300italic,400italic,700italic,400,300,700' rel='stylesheet' type='text/css'> -->
 <link href="../_static/solarized-dark.css" rel="stylesheet">
 <link href="../_static/jquery.treeview.css" rel="stylesheet">
@@ -109,10 +115,6 @@
             
   <div class="section" id="springsecuritylinkagewithbrowser">
 <span id="id1"></span><h1>9.6. ブラウザのセキュリティ対策機能との連携<a class="headerlink" href="#springsecuritylinkagewithbrowser" title="Permalink to this headline">¶</a></h1>
-<div class="admonition caution">
-  <p class="first admonition-title">Caution</p>
-  <p><strong>本バージョンの内容は既に古くなっています</strong>。最新のガイドラインは<a href="http://terasolunaorg.github.io/guideline/">こちら</a>からご参照ください。</p>
-</div>
 <div class="contents local topic" id="id2">
 <p class="topic-title">目次</p>
 <ul class="simple">

--- a/guideline/5.6.0.SP1.RELEASE/ja/Security/OAuth.html
+++ b/guideline/5.6.0.SP1.RELEASE/ja/Security/OAuth.html
@@ -22,7 +22,13 @@
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />
     <link rel="next" title="9.10. 代表的なセキュリティ要件の実装例" href="SecureLoginDemo.html" />
-    <link rel="prev" title="9.8. 暗号化" href="Encryption.html" /><script src="../_static/jquery.treeview.js" type="text/javascript"></script>
+    <link rel="prev" title="9.8. 暗号化" href="Encryption.html" /><script async src="https://www.googletagmanager.com/gtag/js?id=G-847V2Q99G8"></script>
+<script>
+window.dataLayer = window.dataLayer || [];
+function gtag(){dataLayer.push(arguments);}
+gtag('js', new Date()); gtag('config', 'G-847V2Q99G8');
+</script>
+<script src="../_static/jquery.treeview.js" type="text/javascript"></script>
 <!-- <link href='http://fonts.googleapis.com/css?family=Source+Code+Pro|Open+Sans:300italic,400italic,700italic,400,300,700' rel='stylesheet' type='text/css'> -->
 <link href="../_static/solarized-dark.css" rel="stylesheet">
 <link href="../_static/jquery.treeview.css" rel="stylesheet">
@@ -261,10 +267,6 @@
             
   <div class="section" id="oauth">
 <span id="id1"></span><h1>9.9. OAuth<a class="headerlink" href="#oauth" title="Permalink to this headline">¶</a></h1>
-<div class="admonition caution">
-  <p class="first admonition-title">Caution</p>
-  <p><strong>本バージョンの内容は既に古くなっています</strong>。最新のガイドラインは<a href="http://terasolunaorg.github.io/guideline/">こちら</a>からご参照ください。</p>
-</div>
 <div class="contents local topic" id="id2">
 <p class="topic-title">目次</p>
 <ul class="simple">

--- a/guideline/5.6.0.SP1.RELEASE/ja/Security/SecureLoginDemo.html
+++ b/guideline/5.6.0.SP1.RELEASE/ja/Security/SecureLoginDemo.html
@@ -22,7 +22,13 @@
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />
     <link rel="next" title="10. 単体テスト" href="../UnitTest/index.html" />
-    <link rel="prev" title="9.9. OAuth" href="OAuth.html" /><script src="../_static/jquery.treeview.js" type="text/javascript"></script>
+    <link rel="prev" title="9.9. OAuth" href="OAuth.html" /><script async src="https://www.googletagmanager.com/gtag/js?id=G-847V2Q99G8"></script>
+<script>
+window.dataLayer = window.dataLayer || [];
+function gtag(){dataLayer.push(arguments);}
+gtag('js', new Date()); gtag('config', 'G-847V2Q99G8');
+</script>
+<script src="../_static/jquery.treeview.js" type="text/javascript"></script>
 <!-- <link href='http://fonts.googleapis.com/css?family=Source+Code+Pro|Open+Sans:300italic,400italic,700italic,400,300,700' rel='stylesheet' type='text/css'> -->
 <link href="../_static/solarized-dark.css" rel="stylesheet">
 <link href="../_static/jquery.treeview.css" rel="stylesheet">
@@ -200,10 +206,6 @@
             
   <div class="section" id="id1">
 <h1>9.10. 代表的なセキュリティ要件の実装例<a class="headerlink" href="#id1" title="Permalink to this headline">¶</a></h1>
-<div class="admonition caution">
-  <p class="first admonition-title">Caution</p>
-  <p><strong>本バージョンの内容は既に古くなっています</strong>。最新のガイドラインは<a href="http://terasolunaorg.github.io/guideline/">こちら</a>からご参照ください。</p>
-</div>
 <div class="contents local topic" id="id2">
 <p class="topic-title">目次</p>
 <ul class="simple">

--- a/guideline/5.6.0.SP1.RELEASE/ja/Security/SessionManagement.html
+++ b/guideline/5.6.0.SP1.RELEASE/ja/Security/SessionManagement.html
@@ -22,7 +22,13 @@
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />
     <link rel="next" title="9.5. CSRF対策" href="CSRF.html" />
-    <link rel="prev" title="9.3. 認可" href="Authorization.html" /><script src="../_static/jquery.treeview.js" type="text/javascript"></script>
+    <link rel="prev" title="9.3. 認可" href="Authorization.html" /><script async src="https://www.googletagmanager.com/gtag/js?id=G-847V2Q99G8"></script>
+<script>
+window.dataLayer = window.dataLayer || [];
+function gtag(){dataLayer.push(arguments);}
+gtag('js', new Date()); gtag('config', 'G-847V2Q99G8');
+</script>
+<script src="../_static/jquery.treeview.js" type="text/javascript"></script>
 <!-- <link href='http://fonts.googleapis.com/css?family=Source+Code+Pro|Open+Sans:300italic,400italic,700italic,400,300,700' rel='stylesheet' type='text/css'> -->
 <link href="../_static/solarized-dark.css" rel="stylesheet">
 <link href="../_static/jquery.treeview.css" rel="stylesheet">
@@ -124,10 +130,6 @@
             
   <div class="section" id="springsecuritysessionmanagement">
 <span id="id1"></span><h1>9.4. セッション管理<a class="headerlink" href="#springsecuritysessionmanagement" title="Permalink to this headline">¶</a></h1>
-<div class="admonition caution">
-  <p class="first admonition-title">Caution</p>
-  <p><strong>本バージョンの内容は既に古くなっています</strong>。最新のガイドラインは<a href="http://terasolunaorg.github.io/guideline/">こちら</a>からご参照ください。</p>
-</div>
 <div class="contents local topic" id="id2">
 <p class="topic-title">目次</p>
 <ul class="simple">

--- a/guideline/5.6.0.SP1.RELEASE/ja/Security/SpringSecurity.html
+++ b/guideline/5.6.0.SP1.RELEASE/ja/Security/SpringSecurity.html
@@ -22,7 +22,13 @@
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />
     <link rel="next" title="9.2. 認証" href="Authentication.html" />
-    <link rel="prev" title="9. セキュリティ対策" href="index.html" /><script src="../_static/jquery.treeview.js" type="text/javascript"></script>
+    <link rel="prev" title="9. セキュリティ対策" href="index.html" /><script async src="https://www.googletagmanager.com/gtag/js?id=G-847V2Q99G8"></script>
+<script>
+window.dataLayer = window.dataLayer || [];
+function gtag(){dataLayer.push(arguments);}
+gtag('js', new Date()); gtag('config', 'G-847V2Q99G8');
+</script>
+<script src="../_static/jquery.treeview.js" type="text/javascript"></script>
 <!-- <link href='http://fonts.googleapis.com/css?family=Source+Code+Pro|Open+Sans:300italic,400italic,700italic,400,300,700' rel='stylesheet' type='text/css'> -->
 <link href="../_static/solarized-dark.css" rel="stylesheet">
 <link href="../_static/jquery.treeview.css" rel="stylesheet">
@@ -117,10 +123,6 @@
             
   <div class="section" id="spring-security">
 <span id="springsecurityoverview"></span><h1>9.1. Spring Security概要<a class="headerlink" href="#spring-security" title="Permalink to this headline">¶</a></h1>
-<div class="admonition caution">
-  <p class="first admonition-title">Caution</p>
-  <p><strong>本バージョンの内容は既に古くなっています</strong>。最新のガイドラインは<a href="http://terasolunaorg.github.io/guideline/">こちら</a>からご参照ください。</p>
-</div>
 <div class="contents local topic" id="id1">
 <p class="topic-title">目次</p>
 <ul class="simple">

--- a/guideline/5.6.0.SP1.RELEASE/ja/Security/XSS.html
+++ b/guideline/5.6.0.SP1.RELEASE/ja/Security/XSS.html
@@ -22,7 +22,13 @@
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />
     <link rel="next" title="9.8. 暗号化" href="Encryption.html" />
-    <link rel="prev" title="9.6. ブラウザのセキュリティ対策機能との連携" href="LinkageWithBrowser.html" /><script src="../_static/jquery.treeview.js" type="text/javascript"></script>
+    <link rel="prev" title="9.6. ブラウザのセキュリティ対策機能との連携" href="LinkageWithBrowser.html" /><script async src="https://www.googletagmanager.com/gtag/js?id=G-847V2Q99G8"></script>
+<script>
+window.dataLayer = window.dataLayer || [];
+function gtag(){dataLayer.push(arguments);}
+gtag('js', new Date()); gtag('config', 'G-847V2Q99G8');
+</script>
+<script src="../_static/jquery.treeview.js" type="text/javascript"></script>
 <!-- <link href='http://fonts.googleapis.com/css?family=Source+Code+Pro|Open+Sans:300italic,400italic,700italic,400,300,700' rel='stylesheet' type='text/css'> -->
 <link href="../_static/solarized-dark.css" rel="stylesheet">
 <link href="../_static/jquery.treeview.css" rel="stylesheet">
@@ -110,10 +116,6 @@
             
   <div class="section" id="xss">
 <h1>9.7. XSS対策<a class="headerlink" href="#xss" title="Permalink to this headline">¶</a></h1>
-<div class="admonition caution">
-  <p class="first admonition-title">Caution</p>
-  <p><strong>本バージョンの内容は既に古くなっています</strong>。最新のガイドラインは<a href="http://terasolunaorg.github.io/guideline/">こちら</a>からご参照ください。</p>
-</div>
 <div class="contents local topic" id="id1">
 <p class="topic-title">目次</p>
 <ul class="simple">

--- a/guideline/5.6.0.SP1.RELEASE/ja/Security/index.html
+++ b/guideline/5.6.0.SP1.RELEASE/ja/Security/index.html
@@ -22,7 +22,13 @@
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />
     <link rel="next" title="9.1. Spring Security概要" href="SpringSecurity.html" />
-    <link rel="prev" title="8.2. JMS(Java Message Service)" href="../ArchitectureInDetail/MessagingDetail/JMS.html" /><script src="../_static/jquery.treeview.js" type="text/javascript"></script>
+    <link rel="prev" title="8.2. JMS(Java Message Service)" href="../ArchitectureInDetail/MessagingDetail/JMS.html" /><script async src="https://www.googletagmanager.com/gtag/js?id=G-847V2Q99G8"></script>
+<script>
+window.dataLayer = window.dataLayer || [];
+function gtag(){dataLayer.push(arguments);}
+gtag('js', new Date()); gtag('config', 'G-847V2Q99G8');
+</script>
+<script src="../_static/jquery.treeview.js" type="text/javascript"></script>
 <!-- <link href='http://fonts.googleapis.com/css?family=Source+Code+Pro|Open+Sans:300italic,400italic,700italic,400,300,700' rel='stylesheet' type='text/css'> -->
 <link href="../_static/solarized-dark.css" rel="stylesheet">
 <link href="../_static/jquery.treeview.css" rel="stylesheet">
@@ -80,10 +86,6 @@
             
   <div class="section" id="id1">
 <h1>9. セキュリティ対策<a class="headerlink" href="#id1" title="Permalink to this headline">¶</a></h1>
-<div class="admonition caution">
-  <p class="first admonition-title">Caution</p>
-  <p><strong>本バージョンの内容は既に古くなっています</strong>。最新のガイドラインは<a href="http://terasolunaorg.github.io/guideline/">こちら</a>からご参照ください。</p>
-</div>
 <div class="toctree-wrapper compound">
 <ul>
 <li class="toctree-l1"><a class="reference internal" href="SpringSecurity.html">9.1. Spring Security概要</a></li>

--- a/guideline/5.6.0.SP1.RELEASE/ja/Tutorial/TutorialREST.html
+++ b/guideline/5.6.0.SP1.RELEASE/ja/Tutorial/TutorialREST.html
@@ -22,7 +22,13 @@
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />
     <link rel="next" title="11.3. セッションチュートリアル" href="TutorialSession.html" />
-    <link rel="prev" title="11.1. チュートリアル(Todoアプリケーション)" href="TutorialTodo.html" /><script src="../_static/jquery.treeview.js" type="text/javascript"></script>
+    <link rel="prev" title="11.1. チュートリアル(Todoアプリケーション)" href="TutorialTodo.html" /><script async src="https://www.googletagmanager.com/gtag/js?id=G-847V2Q99G8"></script>
+<script>
+window.dataLayer = window.dataLayer || [];
+function gtag(){dataLayer.push(arguments);}
+gtag('js', new Date()); gtag('config', 'G-847V2Q99G8');
+</script>
+<script src="../_static/jquery.treeview.js" type="text/javascript"></script>
 <!-- <link href='http://fonts.googleapis.com/css?family=Source+Code+Pro|Open+Sans:300italic,400italic,700italic,400,300,700' rel='stylesheet' type='text/css'> -->
 <link href="../_static/solarized-dark.css" rel="stylesheet">
 <link href="../_static/jquery.treeview.css" rel="stylesheet">
@@ -141,10 +147,6 @@
             
   <div class="section" id="todo-rest">
 <h1>11.2. チュートリアル(Todoアプリケーション REST編)<a class="headerlink" href="#todo-rest" title="Permalink to this headline">¶</a></h1>
-<div class="admonition caution">
-  <p class="first admonition-title">Caution</p>
-  <p><strong>本バージョンの内容は既に古くなっています</strong>。最新のガイドラインは<a href="http://terasolunaorg.github.io/guideline/">こちら</a>からご参照ください。</p>
-</div>
 <div class="contents local topic" id="id1">
 <p class="topic-title">目次</p>
 <ul class="simple">

--- a/guideline/5.6.0.SP1.RELEASE/ja/Tutorial/TutorialSecurity.html
+++ b/guideline/5.6.0.SP1.RELEASE/ja/Tutorial/TutorialSecurity.html
@@ -22,7 +22,13 @@
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />
     <link rel="next" title="12. Appendix(Know How)" href="../Appendix/index.html" />
-    <link rel="prev" title="11.3. セッションチュートリアル" href="TutorialSession.html" /><script src="../_static/jquery.treeview.js" type="text/javascript"></script>
+    <link rel="prev" title="11.3. セッションチュートリアル" href="TutorialSession.html" /><script async src="https://www.googletagmanager.com/gtag/js?id=G-847V2Q99G8"></script>
+<script>
+window.dataLayer = window.dataLayer || [];
+function gtag(){dataLayer.push(arguments);}
+gtag('js', new Date()); gtag('config', 'G-847V2Q99G8');
+</script>
+<script src="../_static/jquery.treeview.js" type="text/javascript"></script>
 <!-- <link href='http://fonts.googleapis.com/css?family=Source+Code+Pro|Open+Sans:300italic,400italic,700italic,400,300,700' rel='stylesheet' type='text/css'> -->
 <link href="../_static/solarized-dark.css" rel="stylesheet">
 <link href="../_static/jquery.treeview.css" rel="stylesheet">
@@ -130,10 +136,6 @@
             
   <div class="section" id="spring-security">
 <h1>11.4. Spring Securityチュートリアル<a class="headerlink" href="#spring-security" title="Permalink to this headline">¶</a></h1>
-<div class="admonition caution">
-  <p class="first admonition-title">Caution</p>
-  <p><strong>本バージョンの内容は既に古くなっています</strong>。最新のガイドラインは<a href="http://terasolunaorg.github.io/guideline/">こちら</a>からご参照ください。</p>
-</div>
 <div class="contents local topic" id="id1">
 <p class="topic-title">目次</p>
 <ul class="simple">

--- a/guideline/5.6.0.SP1.RELEASE/ja/Tutorial/TutorialSession.html
+++ b/guideline/5.6.0.SP1.RELEASE/ja/Tutorial/TutorialSession.html
@@ -22,7 +22,13 @@
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />
     <link rel="next" title="11.4. Spring Securityチュートリアル" href="TutorialSecurity.html" />
-    <link rel="prev" title="11.2. チュートリアル(Todoアプリケーション REST編)" href="TutorialREST.html" /><script src="../_static/jquery.treeview.js" type="text/javascript"></script>
+    <link rel="prev" title="11.2. チュートリアル(Todoアプリケーション REST編)" href="TutorialREST.html" /><script async src="https://www.googletagmanager.com/gtag/js?id=G-847V2Q99G8"></script>
+<script>
+window.dataLayer = window.dataLayer || [];
+function gtag(){dataLayer.push(arguments);}
+gtag('js', new Date()); gtag('config', 'G-847V2Q99G8');
+</script>
+<script src="../_static/jquery.treeview.js" type="text/javascript"></script>
 <!-- <link href='http://fonts.googleapis.com/css?family=Source+Code+Pro|Open+Sans:300italic,400italic,700italic,400,300,700' rel='stylesheet' type='text/css'> -->
 <link href="../_static/solarized-dark.css" rel="stylesheet">
 <link href="../_static/jquery.treeview.css" rel="stylesheet">
@@ -168,10 +174,6 @@
             
   <div class="section" id="id1">
 <h1>11.3. セッションチュートリアル<a class="headerlink" href="#id1" title="Permalink to this headline">¶</a></h1>
-<div class="admonition caution">
-  <p class="first admonition-title">Caution</p>
-  <p><strong>本バージョンの内容は既に古くなっています</strong>。最新のガイドラインは<a href="http://terasolunaorg.github.io/guideline/">こちら</a>からご参照ください。</p>
-</div>
 <div class="contents local topic" id="id2">
 <p class="topic-title">目次</p>
 <ul class="simple">

--- a/guideline/5.6.0.SP1.RELEASE/ja/Tutorial/TutorialTodo.html
+++ b/guideline/5.6.0.SP1.RELEASE/ja/Tutorial/TutorialTodo.html
@@ -22,7 +22,13 @@
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />
     <link rel="next" title="11.2. チュートリアル(Todoアプリケーション REST編)" href="TutorialREST.html" />
-    <link rel="prev" title="11. チュートリアル" href="index.html" /><script src="../_static/jquery.treeview.js" type="text/javascript"></script>
+    <link rel="prev" title="11. チュートリアル" href="index.html" /><script async src="https://www.googletagmanager.com/gtag/js?id=G-847V2Q99G8"></script>
+<script>
+window.dataLayer = window.dataLayer || [];
+function gtag(){dataLayer.push(arguments);}
+gtag('js', new Date()); gtag('config', 'G-847V2Q99G8');
+</script>
+<script src="../_static/jquery.treeview.js" type="text/javascript"></script>
 <!-- <link href='http://fonts.googleapis.com/css?family=Source+Code+Pro|Open+Sans:300italic,400italic,700italic,400,300,700' rel='stylesheet' type='text/css'> -->
 <link href="../_static/solarized-dark.css" rel="stylesheet">
 <link href="../_static/jquery.treeview.css" rel="stylesheet">
@@ -205,10 +211,6 @@
             
   <div class="section" id="todo">
 <h1>11.1. チュートリアル(Todoアプリケーション)<a class="headerlink" href="#todo" title="Permalink to this headline">¶</a></h1>
-<div class="admonition caution">
-  <p class="first admonition-title">Caution</p>
-  <p><strong>本バージョンの内容は既に古くなっています</strong>。最新のガイドラインは<a href="http://terasolunaorg.github.io/guideline/">こちら</a>からご参照ください。</p>
-</div>
 <div class="contents local topic" id="id1">
 <p class="topic-title">目次</p>
 <ul class="simple">

--- a/guideline/5.6.0.SP1.RELEASE/ja/Tutorial/index.html
+++ b/guideline/5.6.0.SP1.RELEASE/ja/Tutorial/index.html
@@ -22,7 +22,13 @@
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />
     <link rel="next" title="11.1. チュートリアル(Todoアプリケーション)" href="TutorialTodo.html" />
-    <link rel="prev" title="10.3. 単体テストの実行" href="../UnitTest/RunUnitTest.html" /><script src="../_static/jquery.treeview.js" type="text/javascript"></script>
+    <link rel="prev" title="10.3. 単体テストの実行" href="../UnitTest/RunUnitTest.html" /><script async src="https://www.googletagmanager.com/gtag/js?id=G-847V2Q99G8"></script>
+<script>
+window.dataLayer = window.dataLayer || [];
+function gtag(){dataLayer.push(arguments);}
+gtag('js', new Date()); gtag('config', 'G-847V2Q99G8');
+</script>
+<script src="../_static/jquery.treeview.js" type="text/javascript"></script>
 <!-- <link href='http://fonts.googleapis.com/css?family=Source+Code+Pro|Open+Sans:300italic,400italic,700italic,400,300,700' rel='stylesheet' type='text/css'> -->
 <link href="../_static/solarized-dark.css" rel="stylesheet">
 <link href="../_static/jquery.treeview.css" rel="stylesheet">
@@ -80,10 +86,6 @@
             
   <div class="section" id="id1">
 <h1>11. チュートリアル<a class="headerlink" href="#id1" title="Permalink to this headline">¶</a></h1>
-<div class="admonition caution">
-  <p class="first admonition-title">Caution</p>
-  <p><strong>本バージョンの内容は既に古くなっています</strong>。最新のガイドラインは<a href="http://terasolunaorg.github.io/guideline/">こちら</a>からご参照ください。</p>
-</div>
 <div class="toctree-wrapper compound">
 <ul>
 <li class="toctree-l1"><a class="reference internal" href="TutorialTodo.html">11.1. チュートリアル(Todoアプリケーション)</a></li>

--- a/guideline/5.6.0.SP1.RELEASE/ja/UnitTest/ImplementsOfUnitTest/ImplementsOfTestByFunction.html
+++ b/guideline/5.6.0.SP1.RELEASE/ja/UnitTest/ImplementsOfUnitTest/ImplementsOfTestByFunction.html
@@ -22,7 +22,13 @@
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />
     <link rel="next" title="10.2.4. 単体テストで利用するOSSライブラリの使い方" href="UsageOfLibraryForTest.html" />
-    <link rel="prev" title="10.2.2. レイヤごとのテスト実装" href="ImplementsOfTestByLayer.html" /><script src="../../_static/jquery.treeview.js" type="text/javascript"></script>
+    <link rel="prev" title="10.2.2. レイヤごとのテスト実装" href="ImplementsOfTestByLayer.html" /><script async src="https://www.googletagmanager.com/gtag/js?id=G-847V2Q99G8"></script>
+<script>
+window.dataLayer = window.dataLayer || [];
+function gtag(){dataLayer.push(arguments);}
+gtag('js', new Date()); gtag('config', 'G-847V2Q99G8');
+</script>
+<script src="../../_static/jquery.treeview.js" type="text/javascript"></script>
 <!-- <link href='http://fonts.googleapis.com/css?family=Source+Code+Pro|Open+Sans:300italic,400italic,700italic,400,300,700' rel='stylesheet' type='text/css'> -->
 <link href="../../_static/solarized-dark.css" rel="stylesheet">
 <link href="../../_static/jquery.treeview.css" rel="stylesheet">
@@ -98,10 +104,6 @@
             
   <div class="section" id="implementsoftestbyfunction">
 <span id="id1"></span><h1>10.2.3. 機能ごとのテスト実装<a class="headerlink" href="#implementsoftestbyfunction" title="Permalink to this headline">¶</a></h1>
-<div class="admonition caution">
-  <p class="first admonition-title">Caution</p>
-  <p><strong>本バージョンの内容は既に古くなっています</strong>。最新のガイドラインは<a href="http://terasolunaorg.github.io/guideline/">こちら</a>からご参照ください。</p>
-</div>
 <div class="contents local topic" id="id2">
 <p class="topic-title">目次</p>
 <ul class="simple">

--- a/guideline/5.6.0.SP1.RELEASE/ja/UnitTest/ImplementsOfUnitTest/ImplementsOfTestByLayer.html
+++ b/guideline/5.6.0.SP1.RELEASE/ja/UnitTest/ImplementsOfUnitTest/ImplementsOfTestByLayer.html
@@ -22,7 +22,13 @@
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />
     <link rel="next" title="10.2.3. 機能ごとのテスト実装" href="ImplementsOfTestByFunction.html" />
-    <link rel="prev" title="10.2.1. テストの事前準備" href="PreparationForTest.html" /><script src="../../_static/jquery.treeview.js" type="text/javascript"></script>
+    <link rel="prev" title="10.2.1. テストの事前準備" href="PreparationForTest.html" /><script async src="https://www.googletagmanager.com/gtag/js?id=G-847V2Q99G8"></script>
+<script>
+window.dataLayer = window.dataLayer || [];
+function gtag(){dataLayer.push(arguments);}
+gtag('js', new Date()); gtag('config', 'G-847V2Q99G8');
+</script>
+<script src="../../_static/jquery.treeview.js" type="text/javascript"></script>
 <!-- <link href='http://fonts.googleapis.com/css?family=Source+Code+Pro|Open+Sans:300italic,400italic,700italic,400,300,700' rel='stylesheet' type='text/css'> -->
 <link href="../../_static/solarized-dark.css" rel="stylesheet">
 <link href="../../_static/jquery.treeview.css" rel="stylesheet">
@@ -116,10 +122,6 @@
             
   <div class="section" id="implementsoftestbylayer">
 <span id="id1"></span><h1>10.2.2. レイヤごとのテスト実装<a class="headerlink" href="#implementsoftestbylayer" title="Permalink to this headline">¶</a></h1>
-<div class="admonition caution">
-  <p class="first admonition-title">Caution</p>
-  <p><strong>本バージョンの内容は既に古くなっています</strong>。最新のガイドラインは<a href="http://terasolunaorg.github.io/guideline/">こちら</a>からご参照ください。</p>
-</div>
 <div class="contents local topic" id="id2">
 <p class="topic-title">目次</p>
 <ul class="simple">

--- a/guideline/5.6.0.SP1.RELEASE/ja/UnitTest/ImplementsOfUnitTest/PreparationForTest.html
+++ b/guideline/5.6.0.SP1.RELEASE/ja/UnitTest/ImplementsOfUnitTest/PreparationForTest.html
@@ -22,7 +22,13 @@
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />
     <link rel="next" title="10.2.2. レイヤごとのテスト実装" href="ImplementsOfTestByLayer.html" />
-    <link rel="prev" title="10.2. 単体テストの実装" href="index.html" /><script src="../../_static/jquery.treeview.js" type="text/javascript"></script>
+    <link rel="prev" title="10.2. 単体テストの実装" href="index.html" /><script async src="https://www.googletagmanager.com/gtag/js?id=G-847V2Q99G8"></script>
+<script>
+window.dataLayer = window.dataLayer || [];
+function gtag(){dataLayer.push(arguments);}
+gtag('js', new Date()); gtag('config', 'G-847V2Q99G8');
+</script>
+<script src="../../_static/jquery.treeview.js" type="text/javascript"></script>
 <!-- <link href='http://fonts.googleapis.com/css?family=Source+Code+Pro|Open+Sans:300italic,400italic,700italic,400,300,700' rel='stylesheet' type='text/css'> -->
 <link href="../../_static/solarized-dark.css" rel="stylesheet">
 <link href="../../_static/jquery.treeview.css" rel="stylesheet">
@@ -96,10 +102,6 @@
             
   <div class="section" id="preparationfortest">
 <span id="id1"></span><h1>10.2.1. テストの事前準備<a class="headerlink" href="#preparationfortest" title="Permalink to this headline">¶</a></h1>
-<div class="admonition caution">
-  <p class="first admonition-title">Caution</p>
-  <p><strong>本バージョンの内容は既に古くなっています</strong>。最新のガイドラインは<a href="http://terasolunaorg.github.io/guideline/">こちら</a>からご参照ください。</p>
-</div>
 <div class="contents local topic" id="id2">
 <p class="topic-title">目次</p>
 <ul class="simple">

--- a/guideline/5.6.0.SP1.RELEASE/ja/UnitTest/ImplementsOfUnitTest/UsageOfLibraryForTest.html
+++ b/guideline/5.6.0.SP1.RELEASE/ja/UnitTest/ImplementsOfUnitTest/UsageOfLibraryForTest.html
@@ -22,7 +22,13 @@
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />
     <link rel="next" title="10.3. 単体テストの実行" href="../RunUnitTest.html" />
-    <link rel="prev" title="10.2.3. 機能ごとのテスト実装" href="ImplementsOfTestByFunction.html" /><script src="../../_static/jquery.treeview.js" type="text/javascript"></script>
+    <link rel="prev" title="10.2.3. 機能ごとのテスト実装" href="ImplementsOfTestByFunction.html" /><script async src="https://www.googletagmanager.com/gtag/js?id=G-847V2Q99G8"></script>
+<script>
+window.dataLayer = window.dataLayer || [];
+function gtag(){dataLayer.push(arguments);}
+gtag('js', new Date()); gtag('config', 'G-847V2Q99G8');
+</script>
+<script src="../../_static/jquery.treeview.js" type="text/javascript"></script>
 <!-- <link href='http://fonts.googleapis.com/css?family=Source+Code+Pro|Open+Sans:300italic,400italic,700italic,400,300,700' rel='stylesheet' type='text/css'> -->
 <link href="../../_static/solarized-dark.css" rel="stylesheet">
 <link href="../../_static/jquery.treeview.css" rel="stylesheet">
@@ -138,10 +144,6 @@
             
   <div class="section" id="oss">
 <span id="usageoflibraryfortest"></span><h1>10.2.4. 単体テストで利用するOSSライブラリの使い方<a class="headerlink" href="#oss" title="Permalink to this headline">¶</a></h1>
-<div class="admonition caution">
-  <p class="first admonition-title">Caution</p>
-  <p><strong>本バージョンの内容は既に古くなっています</strong>。最新のガイドラインは<a href="http://terasolunaorg.github.io/guideline/">こちら</a>からご参照ください。</p>
-</div>
 <div class="contents local topic" id="id1">
 <p class="topic-title">目次</p>
 <ul class="simple">

--- a/guideline/5.6.0.SP1.RELEASE/ja/UnitTest/ImplementsOfUnitTest/index.html
+++ b/guideline/5.6.0.SP1.RELEASE/ja/UnitTest/ImplementsOfUnitTest/index.html
@@ -22,7 +22,13 @@
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />
     <link rel="next" title="10.2.1. テストの事前準備" href="PreparationForTest.html" />
-    <link rel="prev" title="10.1. 単体テスト概要" href="../UnitTestOverview.html" /><script src="../../_static/jquery.treeview.js" type="text/javascript"></script>
+    <link rel="prev" title="10.1. 単体テスト概要" href="../UnitTestOverview.html" /><script async src="https://www.googletagmanager.com/gtag/js?id=G-847V2Q99G8"></script>
+<script>
+window.dataLayer = window.dataLayer || [];
+function gtag(){dataLayer.push(arguments);}
+gtag('js', new Date()); gtag('config', 'G-847V2Q99G8');
+</script>
+<script src="../../_static/jquery.treeview.js" type="text/javascript"></script>
 <!-- <link href='http://fonts.googleapis.com/css?family=Source+Code+Pro|Open+Sans:300italic,400italic,700italic,400,300,700' rel='stylesheet' type='text/css'> -->
 <link href="../../_static/solarized-dark.css" rel="stylesheet">
 <link href="../../_static/jquery.treeview.css" rel="stylesheet">
@@ -81,10 +87,6 @@
             
   <div class="section" id="id1">
 <h1>10.2. 単体テストの実装<a class="headerlink" href="#id1" title="Permalink to this headline">¶</a></h1>
-<div class="admonition caution">
-  <p class="first admonition-title">Caution</p>
-  <p><strong>本バージョンの内容は既に古くなっています</strong>。最新のガイドラインは<a href="http://terasolunaorg.github.io/guideline/">こちら</a>からご参照ください。</p>
-</div>
 <div class="toctree-wrapper compound">
 <ul>
 <li class="toctree-l1"><a class="reference internal" href="PreparationForTest.html">10.2.1. テストの事前準備</a></li>

--- a/guideline/5.6.0.SP1.RELEASE/ja/UnitTest/RunUnitTest.html
+++ b/guideline/5.6.0.SP1.RELEASE/ja/UnitTest/RunUnitTest.html
@@ -22,7 +22,13 @@
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />
     <link rel="next" title="11. チュートリアル" href="../Tutorial/index.html" />
-    <link rel="prev" title="10.2.4. 単体テストで利用するOSSライブラリの使い方" href="ImplementsOfUnitTest/UsageOfLibraryForTest.html" /><script src="../_static/jquery.treeview.js" type="text/javascript"></script>
+    <link rel="prev" title="10.2.4. 単体テストで利用するOSSライブラリの使い方" href="ImplementsOfUnitTest/UsageOfLibraryForTest.html" /><script async src="https://www.googletagmanager.com/gtag/js?id=G-847V2Q99G8"></script>
+<script>
+window.dataLayer = window.dataLayer || [];
+function gtag(){dataLayer.push(arguments);}
+gtag('js', new Date()); gtag('config', 'G-847V2Q99G8');
+</script>
+<script src="../_static/jquery.treeview.js" type="text/javascript"></script>
 <!-- <link href='http://fonts.googleapis.com/css?family=Source+Code+Pro|Open+Sans:300italic,400italic,700italic,400,300,700' rel='stylesheet' type='text/css'> -->
 <link href="../_static/solarized-dark.css" rel="stylesheet">
 <link href="../_static/jquery.treeview.css" rel="stylesheet">
@@ -102,10 +108,6 @@
             
   <div class="section" id="rununittest">
 <span id="id1"></span><h1>10.3. 単体テストの実行<a class="headerlink" href="#rununittest" title="Permalink to this headline">¶</a></h1>
-<div class="admonition caution">
-  <p class="first admonition-title">Caution</p>
-  <p><strong>本バージョンの内容は既に古くなっています</strong>。最新のガイドラインは<a href="http://terasolunaorg.github.io/guideline/">こちら</a>からご参照ください。</p>
-</div>
 <div class="contents local topic" id="id2">
 <p class="topic-title">目次</p>
 <ul class="simple">

--- a/guideline/5.6.0.SP1.RELEASE/ja/UnitTest/UnitTestOverview.html
+++ b/guideline/5.6.0.SP1.RELEASE/ja/UnitTest/UnitTestOverview.html
@@ -22,7 +22,13 @@
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />
     <link rel="next" title="10.2. 単体テストの実装" href="ImplementsOfUnitTest/index.html" />
-    <link rel="prev" title="10. 単体テスト" href="index.html" /><script src="../_static/jquery.treeview.js" type="text/javascript"></script>
+    <link rel="prev" title="10. 単体テスト" href="index.html" /><script async src="https://www.googletagmanager.com/gtag/js?id=G-847V2Q99G8"></script>
+<script>
+window.dataLayer = window.dataLayer || [];
+function gtag(){dataLayer.push(arguments);}
+gtag('js', new Date()); gtag('config', 'G-847V2Q99G8');
+</script>
+<script src="../_static/jquery.treeview.js" type="text/javascript"></script>
 <!-- <link href='http://fonts.googleapis.com/css?family=Source+Code+Pro|Open+Sans:300italic,400italic,700italic,400,300,700' rel='stylesheet' type='text/css'> -->
 <link href="../_static/solarized-dark.css" rel="stylesheet">
 <link href="../_static/jquery.treeview.css" rel="stylesheet">
@@ -106,10 +112,6 @@
             
   <div class="section" id="id1">
 <h1>10.1. 単体テスト概要<a class="headerlink" href="#id1" title="Permalink to this headline">¶</a></h1>
-<div class="admonition caution">
-  <p class="first admonition-title">Caution</p>
-  <p><strong>本バージョンの内容は既に古くなっています</strong>。最新のガイドラインは<a href="http://terasolunaorg.github.io/guideline/">こちら</a>からご参照ください。</p>
-</div>
 <div class="contents local topic" id="id2">
 <p class="topic-title">目次</p>
 <ul class="simple">

--- a/guideline/5.6.0.SP1.RELEASE/ja/UnitTest/index.html
+++ b/guideline/5.6.0.SP1.RELEASE/ja/UnitTest/index.html
@@ -22,7 +22,13 @@
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />
     <link rel="next" title="10.1. 単体テスト概要" href="UnitTestOverview.html" />
-    <link rel="prev" title="9.10. 代表的なセキュリティ要件の実装例" href="../Security/SecureLoginDemo.html" /><script src="../_static/jquery.treeview.js" type="text/javascript"></script>
+    <link rel="prev" title="9.10. 代表的なセキュリティ要件の実装例" href="../Security/SecureLoginDemo.html" /><script async src="https://www.googletagmanager.com/gtag/js?id=G-847V2Q99G8"></script>
+<script>
+window.dataLayer = window.dataLayer || [];
+function gtag(){dataLayer.push(arguments);}
+gtag('js', new Date()); gtag('config', 'G-847V2Q99G8');
+</script>
+<script src="../_static/jquery.treeview.js" type="text/javascript"></script>
 <!-- <link href='http://fonts.googleapis.com/css?family=Source+Code+Pro|Open+Sans:300italic,400italic,700italic,400,300,700' rel='stylesheet' type='text/css'> -->
 <link href="../_static/solarized-dark.css" rel="stylesheet">
 <link href="../_static/jquery.treeview.css" rel="stylesheet">
@@ -80,10 +86,6 @@
             
   <div class="section" id="id1">
 <h1>10. 単体テスト<a class="headerlink" href="#id1" title="Permalink to this headline">¶</a></h1>
-<div class="admonition caution">
-  <p class="first admonition-title">Caution</p>
-  <p><strong>本バージョンの内容は既に古くなっています</strong>。最新のガイドラインは<a href="http://terasolunaorg.github.io/guideline/">こちら</a>からご参照ください。</p>
-</div>
 <div class="toctree-wrapper compound">
 <ul>
 <li class="toctree-l1"><a class="reference internal" href="UnitTestOverview.html">10.1. 単体テスト概要</a></li>

--- a/guideline/5.6.0.SP1.RELEASE/ja/genindex.html
+++ b/guideline/5.6.0.SP1.RELEASE/ja/genindex.html
@@ -21,7 +21,13 @@
     <script type="text/javascript" src="_static/underscore.js"></script>
     <script type="text/javascript" src="_static/doctools.js"></script>
     <link rel="index" title="Index" href="#" />
-    <link rel="search" title="Search" href="search.html" /><script src="_static/jquery.treeview.js" type="text/javascript"></script>
+    <link rel="search" title="Search" href="search.html" /><script async src="https://www.googletagmanager.com/gtag/js?id=G-847V2Q99G8"></script>
+<script>
+window.dataLayer = window.dataLayer || [];
+function gtag(){dataLayer.push(arguments);}
+gtag('js', new Date()); gtag('config', 'G-847V2Q99G8');
+</script>
+<script src="_static/jquery.treeview.js" type="text/javascript"></script>
 <!-- <link href='http://fonts.googleapis.com/css?family=Source+Code+Pro|Open+Sans:300italic,400italic,700italic,400,300,700' rel='stylesheet' type='text/css'> -->
 <link href="_static/solarized-dark.css" rel="stylesheet">
 <link href="_static/jquery.treeview.css" rel="stylesheet">
@@ -63,10 +69,6 @@
             
 
 <h1 id="index">Index</h1>
-<div class="admonition caution">
-  <p class="first admonition-title">Caution</p>
-  <p><strong>本バージョンの内容は既に古くなっています</strong>。最新のガイドラインは<a href="http://terasolunaorg.github.io/guideline/">こちら</a>からご参照ください。</p>
-</div>
 
 <div class="genindex-jumpbox">
  

--- a/guideline/5.6.0.SP1.RELEASE/ja/index.html
+++ b/guideline/5.6.0.SP1.RELEASE/ja/index.html
@@ -21,7 +21,13 @@
     <script type="text/javascript" src="_static/doctools.js"></script>
     <link rel="index" title="Index" href="genindex.html" />
     <link rel="search" title="Search" href="search.html" />
-    <link rel="next" title="1. はじめに" href="Introduction/index.html" /><script src="_static/jquery.treeview.js" type="text/javascript"></script>
+    <link rel="next" title="1. はじめに" href="Introduction/index.html" /><script async src="https://www.googletagmanager.com/gtag/js?id=G-847V2Q99G8"></script>
+<script>
+window.dataLayer = window.dataLayer || [];
+function gtag(){dataLayer.push(arguments);}
+gtag('js', new Date()); gtag('config', 'G-847V2Q99G8');
+</script>
+<script src="_static/jquery.treeview.js" type="text/javascript"></script>
 <!-- <link href='http://fonts.googleapis.com/css?family=Source+Code+Pro|Open+Sans:300italic,400italic,700italic,400,300,700' rel='stylesheet' type='text/css'> -->
 <link href="_static/solarized-dark.css" rel="stylesheet">
 <link href="_static/jquery.treeview.css" rel="stylesheet">
@@ -73,10 +79,6 @@
             
   <div class="section" id="terasoluna-server-framework-for-java-5-x-development-guideline">
 <h1>TERASOLUNA Server Framework for Java (5.x) Development Guideline<a class="headerlink" href="#terasoluna-server-framework-for-java-5-x-development-guideline" title="Permalink to this headline">¶</a></h1>
-<div class="admonition caution">
-  <p class="first admonition-title">Caution</p>
-  <p><strong>本バージョンの内容は既に古くなっています</strong>。最新のガイドラインは<a href="http://terasolunaorg.github.io/guideline/">こちら</a>からご参照ください。</p>
-</div>
 <div class="admonition note">
 <p class="first admonition-title">Note</p>
 <p class="last">内容の誤りやコメントは<a class="reference external" href="https://github.com/terasolunaorg/terasolunaorg.github.com/issues/new">GithubのIssues</a>にご登録お願いします。</p>

--- a/guideline/5.6.0.SP1.RELEASE/ja/search.html
+++ b/guideline/5.6.0.SP1.RELEASE/ja/search.html
@@ -27,7 +27,13 @@
   </script>
   
   <script type="text/javascript" id="searchindexloader"></script>
-  <script src="_static/jquery.treeview.js" type="text/javascript"></script>
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-847V2Q99G8"></script>
+<script>
+window.dataLayer = window.dataLayer || [];
+function gtag(){dataLayer.push(arguments);}
+gtag('js', new Date()); gtag('config', 'G-847V2Q99G8');
+</script>
+<script src="_static/jquery.treeview.js" type="text/javascript"></script>
 <!-- <link href='http://fonts.googleapis.com/css?family=Source+Code+Pro|Open+Sans:300italic,400italic,700italic,400,300,700' rel='stylesheet' type='text/css'> -->
 <link href="_static/solarized-dark.css" rel="stylesheet">
 <link href="_static/jquery.treeview.css" rel="stylesheet">
@@ -56,10 +62,6 @@
           <div class="body" role="main">
             
   <h1 id="search-documentation">Search</h1>
-<div class="admonition caution">
-  <p class="first admonition-title">Caution</p>
-  <p><strong>本バージョンの内容は既に古くなっています</strong>。最新のガイドラインは<a href="http://terasolunaorg.github.io/guideline/">こちら</a>からご参照ください。</p>
-</div>
   <div id="fallback" class="admonition warning">
   <script type="text/javascript">$('#fallback').hide();</script>
   <p>


### PR DESCRIPTION
Please review #196.

set Google Analytics4 to 5.6.0.SP1.RELEASE.

This modification has resulted in a large number of non-GA4 differences, but they are due to different versions of sphinx.

relates to [TSF4J5-2955](https://terasolunaorg.atlassian.net/browse/TSF4J5-2955) .